### PR TITLE
Create dest directory first to avoid unnecessary nesting

### DIFF
--- a/src/xmigrate/main.py
+++ b/src/xmigrate/main.py
@@ -197,7 +197,7 @@ class Migration:
         """
         output_dir.mkdir(parents=True, exist_ok=True)
         params = {"columns": "ID,label,insert_user,insert_date,last_modified", "format": "json"}
-        response = self.source_conn.get(f"/data/projects/{self.source_info.id}/{resource}", params=params)
+        response = self.source_conn.get(f"/data/projects/{self.source_info.id}/{resource}", query=params)
         df = pd.DataFrame(response.json()["ResultSet"]["Result"])
         df.to_csv(output_dir / f"{resource}_metadata.csv", index=False)
 


### PR DESCRIPTION
Closes #29 

There was an unnecessary nested directory within the destination archive e.g. a `test_rsync` directory within the main `test_rsync102` directory which seemed to cause the files to not appear in the UI.