### PR TITLE
Record current migration progress

### DIFF
--- a/src/xmigrate/main.py
+++ b/src/xmigrate/main.py
@@ -6,6 +6,7 @@ import logging
 import pathlib
 import subprocess
 import time
+import urllib.parse
 import xml.etree.ElementTree as ET
 
 import pandas as pd
@@ -499,6 +500,30 @@ class Migration:
             map_type=XnatType.project,
         )
 
+    def _check_subject_exists(
+        self,
+        subject: xnat.core.XNATListing,
+        subjects_id_map_list: list,
+        source_name: str,
+    ) -> None:
+        """Check if subject exists on the destination XNAT instance."""
+        if subject.id not in subjects_id_map_list:
+            self._create_subject(subject)
+            self._create_custom_forms_data(subject)
+            self._export_id_map(
+                resource="subjects",
+                id_map=self.mapper.id_map[XnatType.subject],
+                output_dir=pathlib.Path(f"./output/{source_name}/{self.destination_info.id}"),
+            )
+        else:
+            msg = f"Skipping creation of subject {subject.id} as already exists on destination."
+            self._logger.info(msg)
+            self.mapper.update_id_map(
+                source=subject.id,
+                destination=self.destination_connection.projects[self.destination_info.id].subjects[subject.label],
+                map_type=XnatType.subject,
+            )
+
     def _create_subject(
         self,
         subject: xnat.core.XNATListing,
@@ -544,6 +569,39 @@ class Migration:
             )
         except (KeyError, AttributeError):
             self.subj_failed_count = self.subj_failed_count + 1
+
+    def _check_experiment_exists(
+        self,
+        experiment: xnat.core.XNATListing,
+        subject: xnat.core.XNATListing,
+        experiments_id_map_list: list,
+        source_name: str,
+        destination_datatypes: dict,
+    ) -> None:
+        if experiment.fulldata["meta"]["xsi:type"] not in destination_datatypes:
+            datatype = experiment.fulldata["meta"]["xsi:type"]
+            msg = f"Datatype {datatype} not available on destination server for subject {subject.id}."
+            raise RuntimeError(msg)
+
+        if experiment.id not in experiments_id_map_list:
+            self._create_experiment(experiment)
+            self._create_custom_forms_data(experiment)
+            self._export_id_map(
+                resource="experiments",
+                id_map=self.mapper.id_map[XnatType.experiment],
+                output_dir=pathlib.Path(f"./output/{source_name}/{self.destination_info.id}"),
+            )
+        else:
+            msg = f"Skipping creation of experiment {experiment.id} as already exists on destination."
+            self._logger.info(msg)
+            self.mapper.update_id_map(
+                source=experiment.id,
+                destination=self.destination_connection.projects[self.destination_info.id]
+                .subjects[subject.label]
+                .experiments[experiment.label]
+                .id,
+                map_type=XnatType.experiment,
+            )
 
     def _create_experiment(
         self,
@@ -606,6 +664,30 @@ class Migration:
                 .id,
                 map_type=XnatType.experiment,
             )
+
+    def _check_scan_exists(
+        self,
+        scan: xnat.core.XNATListing,
+        experiment: xnat.core.XNATListing,
+        subject: xnat.core.XNATListing,
+    ) -> None:
+        if (
+            scan.id
+            in self.destination_connection.projects[self.destination_info.id]
+            .subjects[subject.label]
+            .experiments[experiment.label]
+            .scans
+        ):
+            msg = f"Skipping creation of scan {scan.id} as already exists on destination."
+            self._logger.info(msg)
+            self.mapper.update_id_map(
+                source=scan.id,
+                destination=scan.id,  # Scan IDs must be preserved
+                map_type=XnatType.scan,
+            )
+        else:
+            self._create_scan(scan)
+            self._create_custom_forms_data(scan)
 
     def _create_scan(
         self,
@@ -670,6 +752,34 @@ class Migration:
                 destination=scan.id,  # Scan IDs must be preserved
                 map_type=XnatType.scan,
             )
+
+    def _check_assessor_exists(
+        self,
+        assessor: xnat.core.XNATListing,
+        experiment: xnat.core.XNATListing,
+        subject: xnat.core.XNATListing,
+    ) -> None:
+        if (
+            assessor.label
+            in self.destination_connection.projects[self.destination_info.id]
+            .subjects[subject.label]
+            .experiments[experiment.label]
+            .assessors
+        ):
+            msg = f"Skipping creation of scan {assessor.id} as already exists on destination."
+            self._logger.info(msg)
+            self.mapper.update_id_map(
+                source=assessor.id,
+                destination=self.destination_connection.projects[self.destination_info.id]
+                .subjects[subject.label]
+                .experiments[experiment.label]
+                .assessors[assessor.label]
+                .id,
+                map_type=XnatType.assessor,
+            )
+        else:
+            self._create_assessor(assessor)
+            self._create_custom_forms_data(assessor)
 
     def _create_assessor(
         self,
@@ -747,19 +857,16 @@ class Migration:
         destination_project = self.mapper.get_destination_id(source_project, XnatType.project)
         destination_profiles = self.destination_connection.get("/xapi/users/profiles", format="json").json()
 
-        source_name = self.source_conn._original_uri.split(".")[0].split("//")[1]  # noqa: SLF001
-        folder_path = pathlib.Path() / "output" / source_name
+        source_name = urllib.parse.urlparse(self.source_connection._original_uri).hostname.split(".")[0]  # noqa: SLF001
+        folder_path = pathlib.Path(__file__).resolve().parent / "output" / source_name
         folder_path.mkdir(parents=True, exist_ok=True)
         dest_project_id = self.destination_info.id
 
         path = folder_path / "user_permissions_per_project.json"
         if path.is_file():
-            msg = (
-                "user_permissions_per_project.json file exists for "
-                f"{source_name}. Checking progress..."
-          	)
+            msg = f"user_permissions_per_project.json file exists for {source_name}. Checking progress..."
             self._logger.info(msg)
-            with open(path) as file:  # noqa: PTH123
+            with pathlib.Path(path).open() as file:
                 dest_project_ownership = json.load(file)
 
             if dest_project_id not in list(dest_project_ownership.keys()):
@@ -789,10 +896,10 @@ class Migration:
 
         dest_project_ownership[self.destination_info.id] = source_project_ownership
 
-        with open(path, "w") as file:  # noqa: PTH123
+        with pathlib.Path(path).open("w") as file:
             json.dump(dest_project_ownership, file, indent=4)
 
-    def _create_resources(self) -> None:  # noqa: PLR0912, PLR0915
+    def _create_resources(self) -> None:
         """Create all resources on the destination XNAT instance."""
         self._create_project()
         source_project = self.source_connection.projects[self.source_info.id]
@@ -824,10 +931,10 @@ class Migration:
             return
 
         self._create_custom_forms_data(source_project)
-        self._assign_user_permissions_per_project()
+        self._assign_user_permissions_per_project(source_project)
 
         destination_datatypes = self.destination_connection.get("/xapi/schemas/datatypes").json()
-        source_name = self.source_connection._original_uri.split(".")[0].split("//")[1]  # noqa: SLF001
+        source_name = urllib.parse.urlparse(self.source_connection._original_uri).hostname.split(".")[0]  # noqa: SLF001
         subj_path = f"output/{source_name}/{self.destination_info.id}/subjects_id_map.csv"
         subj_full_path = pathlib.Path() / subj_path
         if subj_full_path.is_file():
@@ -843,92 +950,18 @@ class Migration:
             experiments_id_map_list = experiments_id_map["source_id"].tolist()
         else:
             experiments_id_map_list = []
- 
+
         for subject in source_project.subjects:
-            if subject.id not in subjects_id_map_list:
-                self._create_subject(subject)
-                self._create_custom_forms_data(subject)
-                self._export_id_map(
-                    resource="subjects",
-                    id_map=self.mapper.id_map[XnatType.subject],
-                    output_dir=pathlib.Path(f"./output/{source_name}/{self.destination_info.id}"),
-                )
-            else:
-                msg = f"Skipping creation of subject {subject.id} as already exists on destination."
-                self._logger.info(msg)
-                self.mapper.update_id_map(
-                    source=subject.id,
-                    destination=self.destination_conn.projects[self.destination_info.id].subjects[subject.label],
-                    map_type=XnatType.subject,
-                )
-
+            self._check_subject_exists(subject, subjects_id_map_list, source_name)
             for experiment in subject.experiments:
-                if experiment.fulldata["meta"]["xsi:type"] not in destination_datatypes:
-                    datatype = experiment.fulldata["meta"]["xsi:type"]
-                    msg = f"Datatype {datatype} not available on destination server for subject {subject.id}."
-                    raise RuntimeError(msg)
-
-                if experiment.id not in experiments_id_map_list:
-                    self._create_experiment(experiment)
-                    self._create_custom_forms_data(experiment)
-                    self._export_id_map(
-                        resource="experiments",
-                        id_map=self.mapper.id_map[XnatType.experiment],
-                        output_dir=pathlib.Path(f"./output/{source_name}/{self.destination_info.id}"),
-                    )
-                else:
-                    msg = f"Skipping creation of experiment {experiment.id} as already exists on destination."
-                    self._logger.info(msg)
-                    self.mapper.update_id_map(
-                        source=experiment.id,
-                        destination=self.destination_conn.projects[self.destination_info.id]
-                        .subjects[subject.label]
-                        .experiments[experiment.label]
-                        .id,
-                        map_type=XnatType.experiment,
-                    )
-
+                self._check_experiment_exists(
+                    experiment, subject, experiments_id_map_list, source_name, destination_datatypes
+                )
                 for scan in experiment.scans:
-                    if (
-                        scan.id
-                        in self.destination_conn.projects[self.destination_info.id]
-                        .subjects[subject.label]
-                        .experiments[experiment.label]
-                        .scans
-                    ):
-                        msg = f"Skipping creation of scan {scan.id} as already exists on destination."
-                        self._logger.info(msg)
-                        self.mapper.update_id_map(
-                            source=scan.id,
-                            destination=scan.id,  # Scan IDs must be preserved
-                            map_type=XnatType.scan,
-                        )
-                    else:
-                        self._create_scan(scan)
-                        self._create_custom_forms_data(scan)
+                    self._check_scan_exists(scan, experiment, subject)
 
                 for assessor in experiment.assessors:
-                    if (
-                        assessor.label
-                        in self.destination_conn.projects[self.destination_info.id]
-                        .subjects[subject.label]
-                        .experiments[experiment.label]
-                        .assessors
-                    ):
-                        msg = f"Skipping creation of scan {scan.id} as already exists on destination."
-                        self._logger.info(msg)
-                        self.mapper.update_id_map(
-                            source=assessor.id,
-                            destination=self.destination_conn.projects[self.destination_info.id]
-                            .subjects[subject.label]
-                            .experiments[experiment.label]
-                            .assessors[assessor.label]
-                            .id,
-                            map_type=XnatType.assessor,
-                        )
-                    else:
-                        self._create_assessor(assessor)
-                        self._create_custom_forms_data(assessor)
+                    self._check_assessor_exists(assessor, experiment, subject)
 
         self._logger.info("Subjects failed: %d", self.subj_failed_count)
         self._logger.info("Total subjects: %d", len(source_project.subjects))
@@ -1101,7 +1134,7 @@ class Migration:
 
             self._logger.info("Migrating project: %s -> %s", source_info.id, destination_info.id)
 
-            source_name = self.source_conn._original_uri.split(".")[0].split("//")[1]  # noqa: SLF001
+            source_name = urllib.parse.urlparse(self.source_connection._original_uri).hostname.split(".")[0]  # noqa: SLF001
             path = f"output/{source_name}/{self.destination_info.id}"
             full_path = f"output/{source_name}/{self.destination_info.id}/subjects_metadata.csv"
             metadata_path_subjects = pathlib.Path() / full_path


### PR DESCRIPTION
Closes #40 

This PR for the `migrate.run()` command:
- Checks `_get_resource_metadata` file already exists for source XNAT for each project in `.csv` files
- Checks `_assign_user_permissions_per_project` for all projects in `.json` file
- Skips subjects and experiments if id_map file already exists for source XNAT for each project in `.csv` files
- Since mapping is 1:1 for scans and assessors, just checks if scans and assessors already exist in destination and then skips if so.

Current layout of files is as below. The csv files were piling up so split into project folders underneath the instance directory:

<img width="748" height="688" alt="image" src="https://github.com/user-attachments/assets/5ccbb33d-0f55-4747-b560-9c19aa1f6392" />

- Fixes minor errors in `create_users` and `_set_project_configs`