### PR TITLE
Fix tests by retrieving openneuro-t1w data from url

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,19 +264,18 @@ def source_connection(
     )
     xnat4tests.start_xnat(config)
 
-    if dataset == "openneuro-t1w":
-        openneuro_cache_path = base_cache_dir / "mri" / "neuro" / "t1w"
-        openneuro_cache_path.mkdir(parents=True, exist_ok=True)
+    openneuro_cache_path = base_cache_dir / "mri" / "neuro" / "t1w"
+    openneuro_cache_path.mkdir(parents=True, exist_ok=True)
 
-        if not any(openneuro_cache_path.iterdir()):
-            openneuro_url_base = "s3.amazonaws.com/openneuro.org/ds002014/sub-01/anat/"
-            local_cache_name = "ds002014-01"
-            url_filename = "sub-01_T1w"
-            for file in [".nii.gz", ".json"]:
-                urllib.request.urlretrieve(
-                    f"https://{openneuro_url_base}{url_filename}{file}",
-                    f"{openneuro_cache_path}/{local_cache_name}{file}",
-                )
+    if not any(openneuro_cache_path.iterdir()):
+        openneuro_url_base = "s3.amazonaws.com/openneuro.org/ds002014/sub-01/anat/"
+        local_cache_name = "ds002014-01"
+        url_filename = "sub-01_T1w"
+        for file in [".nii.gz", ".json"]:
+            urllib.request.urlretrieve(
+                f"https://{openneuro_url_base}{url_filename}{file}",
+                f"{openneuro_cache_path}/{local_cache_name}{file}",
+            )
 
     for dataset in ["dummydicom", "openneuro-t1w"]:
         xnat4tests.add_data(dataset, config_name=config, upload_method="direct")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,10 +10,10 @@ import time
 import urllib.request
 from typing import TYPE_CHECKING
 
+import medimages4tests.cache_dir
 import pytest
 import requests  # type: ignore  # noqa: PGH003
 import xnat4tests
-from medimages4tests.cache_dir import base_cache_dir
 
 from tests.utils import delete_data
 from xmigrate.xml_mapper import ProjectInfo
@@ -264,7 +264,7 @@ def source_connection(
     )
     xnat4tests.start_xnat(config)
 
-    openneuro_cache_path = base_cache_dir / "mri" / "neuro" / "t1w"
+    openneuro_cache_path = medimages4tests.cache_dir.base_cache_dir / "mri" / "neuro" / "t1w"
     openneuro_cache_path.mkdir(parents=True, exist_ok=True)
 
     if not any(openneuro_cache_path.iterdir()):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,20 +264,21 @@ def source_connection(
     )
     xnat4tests.start_xnat(config)
 
-    for dataset in ["dummydicom", "openneuro-t1w"]:
-        if dataset == "openneuro-t1w":
-            openneuro_cache_path = base_cache_dir / "mri" / "neuro" / "t1w"
-            openneuro_cache_path.mkdir(parents=True, exist_ok=True)
+    if dataset == "openneuro-t1w":
+        openneuro_cache_path = base_cache_dir / "mri" / "neuro" / "t1w"
+        openneuro_cache_path.mkdir(parents=True, exist_ok=True)
 
-            if not any(openneuro_cache_path.iterdir()):
-                openneuro_url_base = "s3.amazonaws.com/openneuro.org/ds002014/sub-01/anat/"
-                local_cache_name = "ds002014-01"
-                url_filename = "sub-01_T1w"
-                for file in [".nii.gz", ".json"]:
-                    urllib.request.urlretrieve(
-                        f"https://{openneuro_url_base}{url_filename}{file}",
-                        f"{openneuro_cache_path}/{local_cache_name}{file}",
-                    )
+        if not any(openneuro_cache_path.iterdir()):
+            openneuro_url_base = "s3.amazonaws.com/openneuro.org/ds002014/sub-01/anat/"
+            local_cache_name = "ds002014-01"
+            url_filename = "sub-01_T1w"
+            for file in [".nii.gz", ".json"]:
+                urllib.request.urlretrieve(
+                    f"https://{openneuro_url_base}{url_filename}{file}",
+                    f"{openneuro_cache_path}/{local_cache_name}{file}",
+                )
+
+    for dataset in ["dummydicom", "openneuro-t1w"]:
         xnat4tests.add_data(dataset, config_name=config, upload_method="direct")
 
     connection_name = "xnat4tests_source"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 import pytest
 import requests  # type: ignore  # noqa: PGH003
 import xnat4tests
+from medimages4tests.cache_dir import base_cache_dir
 
 from tests.utils import delete_data
 from xmigrate.xml_mapper import ProjectInfo
@@ -264,6 +265,19 @@ def source_connection(
     xnat4tests.start_xnat(config)
 
     for dataset in ["dummydicom", "openneuro-t1w"]:
+        if dataset == "openneuro-t1w":
+            openneuro_cache_path = base_cache_dir / "mri" / "neuro" / "t1w"
+            openneuro_cache_path.mkdir(parents=True, exist_ok=True)
+
+            if not any(openneuro_cache_path.iterdir()):
+                openneuro_url_base = "s3.amazonaws.com/openneuro.org/ds002014/sub-01/anat/"
+                local_cache_name = "ds002014-01"
+                url_filename = "sub-01_T1w"
+                for file in [".nii.gz", ".json"]:
+                    urllib.request.urlretrieve(
+                        f"https://{openneuro_url_base}{url_filename}{file}",
+                        f"{openneuro_cache_path}/{local_cache_name}{file}",
+                    )
         xnat4tests.add_data(dataset, config_name=config, upload_method="direct")
 
     connection_name = "xnat4tests_source"


### PR DESCRIPTION
Closes #128 

This PR fix the tests failing due to line in `conftest.py` for `openneuro-t1w` dataset with:
`xnat4tests.add_data(dataset, config_name=config, upload_method="direct")`

Checks if the local cache (base_cache_dir i.e. `~/medimages4tests/mri/neuro/t1w`) where the `openneuro-t1w` is stored is empty before retrieving the data via url and storing in the local cache (otherwise `xnat4tests.add_data` doesn't work as the route to retrieve data).

Have opened an issue on [xnat4tests](https://github.com/Australian-Imaging-Service/xnat4tests/issues/31) about this issue referring to [medimages4tests repo](https://github.com/Australian-Imaging-Service/medimages4tests)