### PR TITLE
Unit tests for adding metadata to duckdb

### DIFF
--- a/src/xmigrate/migration.py
+++ b/src/xmigrate/migration.py
@@ -357,6 +357,32 @@ class Migration:
                 msg = f"Failed to migrate custom form data for {resource_type_name} {resource_type.id}: {e}"
                 LOGGER.warning(msg)
 
+    def _get_run_ids(self) -> XMigrateIDs:
+        """Get the IDs for the current migration run."""
+        _source_instance = xdb.insert_instance(
+            self._db,
+            self.source_connection._original_uri,  # noqa: SLF001
+        )
+        _destination_instance = xdb.insert_instance(
+            self._db,
+            self.destination_connection._original_uri,  # noqa: SLF001
+        )
+        _migration_run = xdb.create_migration_run(
+            self._db,
+            source_instance_id=_source_instance,
+            destination_instance_id=_destination_instance,
+        )
+
+        # We cannot set the source_project and destination_project attributes until
+        # we know the they exist in the db (which happens within 'Migration._run')
+        return XMigrateIDs(
+            source_instance=_source_instance,
+            destination_instance=_destination_instance,
+            migration_run=_migration_run,
+            source_project=None,
+            destination_project=None,
+        )
+
     def _load_id_maps(self) -> None:
         """
         Restore already-persisted ID maps from the DB into the current mapper.
@@ -1143,29 +1169,7 @@ class Migration:
         create_custom_forms_json(self.source_connection, self.destination_connection)
 
         with xdb.open_db() as self._db:
-            _source_instance = xdb.insert_instance(
-                self._db,
-                self.source_connection._original_uri,  # noqa: SLF001
-            )
-            _destination_instance = xdb.insert_instance(
-                self._db,
-                self.destination_connection._original_uri,  # noqa: SLF001
-            )
-            _migration_run = xdb.create_migration_run(
-                self._db,
-                source_instance_id=_source_instance,
-                destination_instance_id=_destination_instance,
-            )
-
-            # We cannot set the source_project and destination_project attributes until
-            # we know the they exist in the db (which happens within 'Migration._run')
-            self._xmigrate_ids = XMigrateIDs(
-                source_instance=_source_instance,
-                destination_instance=_destination_instance,
-                migration_run=_migration_run,
-                source_project=None,
-                destination_project=None,
-            )
+            self._xmigrate_ids = self._get_run_ids()
             try:
                 self._run()
             finally:

--- a/src/xmigrate/migration.py
+++ b/src/xmigrate/migration.py
@@ -7,9 +7,9 @@ import pathlib
 import subprocess
 import time
 import xml.etree.ElementTree as ET
+from typing import TYPE_CHECKING
 
 import defusedxml.ElementTree as DefusedET
-import duckdb
 import pandas as pd
 
 import xnat
@@ -21,6 +21,9 @@ from xmigrate.datatypes import check_datatypes_matching
 from xmigrate.plugins import check_plugins_matching
 from xmigrate.users import check_user, check_user_roles
 from xmigrate.xml_mapper import ProjectInfo, XMLMapper, XnatType
+
+if TYPE_CHECKING:
+    import duckdb
 
 # Configure a module-level logger. Keep basicConfig here for simple CLI runs;
 # packages importing this module can configure logging more specifically.
@@ -89,7 +92,7 @@ class Migration:
         self._destination_project_id: int = 0  # updated per-iteration in _create_project
         self.sitewide_roles: dict = {}
 
-        self._db: duckdb.DuckDBPyConnection
+        self._xmigrate_connection: duckdb.DuckDBPyConnection
         self._xmigrate_ids: XMigrateIDs
 
     def _get_source_xml(self, uri: str) -> ET.Element:
@@ -184,15 +187,15 @@ class Migration:
         df = df.rename(columns={"ID": "xnat_id"})
         if resource == "subjects":
             xdb.upsert_subject(
-                self._db,
+                self._xmigrate_connection,
                 instance_id=self._xmigrate_ids.destination_instance,
                 project_id=self._xmigrate_ids.destination_project,
                 owner_project_id=self._xmigrate_ids.destination_project,
                 df=df,
             )
-        else:  # experiments
+        else:
             xdb.upsert_experiment(
-                self._db,
+                self._xmigrate_connection,
                 instance_id=self._xmigrate_ids.destination_instance,
                 project_id=self._xmigrate_ids.destination_project,
                 df=df,
@@ -360,15 +363,15 @@ class Migration:
     def _get_run_ids(self) -> XMigrateIDs:
         """Get the IDs for the current migration run."""
         _source_instance = xdb.insert_instance(
-            self._db,
+            self._xmigrate_connection,
             self.source_connection._original_uri,  # noqa: SLF001
         )
         _destination_instance = xdb.insert_instance(
-            self._db,
+            self._xmigrate_connection,
             self.destination_connection._original_uri,  # noqa: SLF001
         )
         _migration_run = xdb.create_migration_run(
-            self._db,
+            self._xmigrate_connection,
             source_instance_id=_source_instance,
             destination_instance_id=_destination_instance,
         )
@@ -398,7 +401,7 @@ class Migration:
                 continue
 
             self.mapper.id_map[xnat_type] = xdb.get_id_map(
-                conn=self._db,
+                conn=self._xmigrate_connection,
                 resource_type=resource_type,
                 source_project_id=self._xmigrate_ids.source_project,
                 destination_project_id=self._xmigrate_ids.destination_project,
@@ -425,27 +428,27 @@ class Migration:
 
         """
         map_id = xdb.insert_map(
-            self._db,
+            self._xmigrate_connection,
             resource_type=resource_type,
             source_project_id=self._xmigrate_ids.source_project,
             destination_project_id=self._xmigrate_ids.destination_project,
             source_xnat_id=source_xnat_id,
             destination_xnat_id=destination_xnat_id,
         )
-        xdb.record_migration_run_item(self._db, run_id=self._xmigrate_ids.migration_run, map_id=map_id)
+        xdb.record_migration_run_item(self._xmigrate_connection, run_id=self._xmigrate_ids.migration_run, map_id=map_id)
 
     def _create_project(self) -> None:
         """Create the project on the destination XNAT instance."""
         # Register both projects in the DB first so surrogate PKs are
         # available before any id_map export.
         self._xmigrate_ids.source_project = xdb.insert_project(
-            self._db,
+            self._xmigrate_connection,
             instance_id=self._xmigrate_ids.source_instance,
             xnat_id=self.source_info.id,
             secondary_id=self.source_info.secondary_id,
         )
         self._xmigrate_ids.destination_project = xdb.insert_project(
-            self._db,
+            self._xmigrate_connection,
             instance_id=self._xmigrate_ids.destination_instance,
             xnat_id=self.destination_info.id,
             secondary_id=self.destination_info.secondary_id,
@@ -843,7 +846,7 @@ class Migration:
         destination_profiles = self.destination_connection.get("/xapi/users/profiles", format="json").json()
 
         # Resume: skip if permissions have already been persisted for this project.
-        if xdb.get_user_permissions_for_project(self._db, self._xmigrate_ids.destination_project):
+        if xdb.get_user_permissions_for_project(self._xmigrate_connection, self._xmigrate_ids.destination_project):
             msg = f"User permissions already migrated for project {self.destination_info.id}."
             LOGGER.info(msg)
             return
@@ -869,7 +872,7 @@ class Migration:
             self.destination_connection.put(api_put_string)
 
             user_id = xdb.upsert_user(
-                self._db,
+                self._xmigrate_connection,
                 instance_id=self._xmigrate_ids.destination_instance,
                 login=username,
                 firstname=user.get("firstname"),
@@ -877,7 +880,7 @@ class Migration:
                 email=user.get("email"),
             )
             xdb.upsert_user_permission(
-                self._db,
+                self._xmigrate_connection,
                 instance_id=self._xmigrate_ids.destination_instance,
                 project_id=self._xmigrate_ids.destination_project,
                 user_id=user_id,
@@ -1114,7 +1117,7 @@ class Migration:
         """
         dest_project_ids = [
             xdb.insert_project(
-                self._db,
+                self._xmigrate_connection,
                 instance_id=self._xmigrate_ids.destination_instance,
                 xnat_id=destination_info.id,
                 secondary_id=destination_info.secondary_id,
@@ -1132,8 +1135,8 @@ class Migration:
             self.mapper = mapper
             self.source_info = source_info
             self.destination_info = destination_info
-            xdb.sync_subject_metadata(self._db, destination_project_id=dest_project_id)
-            xdb.sync_experiment_metadata(self._db, destination_project_id=dest_project_id)
+            xdb.sync_subject_metadata(self._xmigrate_connection, destination_project_id=dest_project_id)
+            xdb.sync_experiment_metadata(self._xmigrate_connection, destination_project_id=dest_project_id)
 
     def _run(self) -> None:
         """Run the migration process."""
@@ -1168,12 +1171,12 @@ class Migration:
         check_datatypes_matching(self.source_connection, self.destination_connection)
         create_custom_forms_json(self.source_connection, self.destination_connection)
 
-        with xdb.open_db() as self._db:
+        with xdb.open_db() as self._xmigrate_connection:
             self._xmigrate_ids = self._get_run_ids()
             try:
                 self._run()
             finally:
-                xdb.complete_migration_run(self._db, self._xmigrate_ids.migration_run)
+                xdb.complete_migration_run(self._xmigrate_connection, self._xmigrate_ids.migration_run)
 
         end = time.time()
 

--- a/src/xmigrate/migration.py
+++ b/src/xmigrate/migration.py
@@ -9,6 +9,7 @@ import time
 import xml.etree.ElementTree as ET
 
 import defusedxml.ElementTree as DefusedET
+import duckdb
 import pandas as pd
 
 import xnat
@@ -43,9 +44,9 @@ class XMigrateIDs:
     """Surrogate PK for the destination XNAT instance row in xmigrate.duckdb."""
     migration_run: int
     """Surrogate PK for the current migration_run row in xmigrate.duckdb."""
-    source_project: int = 0
+    source_project: int | None = None
     """Surrogate PK for the source project row in xmigrate.duckdb."""
-    destination_project: int = 0
+    destination_project: int | None = None
     """Surrogate PK for the destination project row in xmigrate.duckdb."""
 
 
@@ -85,22 +86,11 @@ class Migration:
         self.experiment_sharing: dict = {}
         self.assessor_sharing: dict = {}
 
-        self._db = xdb.open_db()
-        self._source_instance_id = xdb.insert_instance(
-            self._db,
-            self.source_connection._original_uri,  # noqa: SLF001
-        )
-        self._destination_instance_id = xdb.insert_instance(
-            self._db,
-            self.destination_connection._original_uri,  # noqa: SLF001
-        )
-        self._migration_run_id: int = xdb.create_migration_run(
-            self._db,
-            source_instance_id=self._source_instance_id,
-            destination_instance_id=self._destination_instance_id,
-        )
         self._destination_project_id: int = 0  # updated per-iteration in _create_project
         self.sitewide_roles: dict = {}
+
+        self._db: duckdb.DuckDBPyConnection
+        self._xmigrate_ids: XMigrateIDs
 
     def _get_source_xml(self, uri: str) -> ET.Element:
         """
@@ -1089,31 +1079,6 @@ class Migration:
 
         LOGGER.info("Sharing configurations applied.")
 
-    def _run(self) -> None:
-        """Run the migration process."""
-        # Iterate over all projects
-        for mapper, source_info, destination_info in zip(
-            self.mappers,
-            self.all_source_info,
-            self.all_destination_info,
-            strict=True,
-        ):
-            # Set current project context
-            self.mapper = mapper
-            self.source_info = source_info
-            self.destination_info = destination_info
-
-            LOGGER.info("Migrating project: %s -> %s", source_info.id, destination_info.id)
-            self._create_resources()
-            self._set_project_configs()
-            self._refresh_catalogues()
-
-            # Persist final ID maps and source metadata to the migration DB
-            self._save_resource_metadata_to_db(resource="subjects")
-            self._save_resource_metadata_to_db(resource="experiments")
-
-        self._apply_sharing()
-
     def _sync_destination_metadata(self) -> None:
         """
         Push stored metadata (insert_user, insert_date, last_modified) to the destination.
@@ -1144,6 +1109,31 @@ class Migration:
             xdb.sync_subject_metadata(self._db, destination_project_id=dest_project_id)
             xdb.sync_experiment_metadata(self._db, destination_project_id=dest_project_id)
 
+    def _run(self) -> None:
+        """Run the migration process."""
+        for mapper, source_info, destination_info in zip(
+            self.mappers,
+            self.all_source_info,
+            self.all_destination_info,
+            strict=True,
+        ):
+            # Set current project context
+            self.mapper = mapper
+            self.source_info = source_info
+            self.destination_info = destination_info
+
+            LOGGER.info("Migrating project: %s -> %s", source_info.id, destination_info.id)
+            self._create_resources()
+            self._set_project_configs()
+            self._refresh_catalogues()
+
+            # Persist final ID maps and source metadata to the migration DB
+            self._save_resource_metadata_to_db(resource="subjects")
+            self._save_resource_metadata_to_db(resource="experiments")
+
+        self._apply_sharing()
+        self._sync_destination_metadata()
+
     def run(self) -> None:
         """Migrate a project from source to destination XNAT instance."""
         start = time.time()
@@ -1173,10 +1163,13 @@ class Migration:
                 source_instance=_source_instance,
                 destination_instance=_destination_instance,
                 migration_run=_migration_run,
+                source_project=None,
+                destination_project=None,
             )
-            self._run()
-            self._sync_destination_metadata()
-            xdb.complete_migration_run(self._db, self._xmigrate_ids.migration_run)
+            try:
+                self._run()
+            finally:
+                xdb.complete_migration_run(self._db, self._xmigrate_ids.migration_run)
 
         end = time.time()
 

--- a/src/xmigrate/migration.py
+++ b/src/xmigrate/migration.py
@@ -86,11 +86,11 @@ class Migration:
         self.assessor_sharing: dict = {}
 
         self._db = xdb.open_db()
-        self._source_instance_id = xdb.upsert_instance(
+        self._source_instance_id = xdb.insert_instance(
             self._db,
             self.source_connection._original_uri,  # noqa: SLF001
         )
-        self._destination_instance_id = xdb.upsert_instance(
+        self._destination_instance_id = xdb.insert_instance(
             self._db,
             self.destination_connection._original_uri,  # noqa: SLF001
         )

--- a/src/xmigrate/sql/insert_map.sql
+++ b/src/xmigrate/sql/insert_map.sql
@@ -17,5 +17,5 @@ VALUES (
 )
 ON CONFLICT (
     type, source_project, destination_project, source_xnat_id
-) DO UPDATE SET destination_xnat_id = EXCLUDED.destination_xnat_id
+) DO UPDATE SET destination_xnat_id = excluded.destination_xnat_id
 RETURNING id

--- a/src/xmigrate/sql/insert_or_update_experiment.sql
+++ b/src/xmigrate/sql/insert_or_update_experiment.sql
@@ -13,10 +13,10 @@ SELECT
     $instance,
     $project,
     xnat_id,
-    NULLIF(label, ''),
-    NULLIF(insert_user, ''),
-    NULLIF(insert_date, ''),
-    NULLIF(last_modified, '')
+    NULLIF(label, '') AS lbl,
+    NULLIF(insert_user, '') AS insert_user,
+    NULLIF(insert_date, '') AS insert_date,
+    NULLIF(last_modified, '') AS last_modified
 FROM experiment_df
 ON CONFLICT (instance, project, xnat_id) DO UPDATE SET
     label = excluded.label,

--- a/src/xmigrate/sql/insert_or_update_subject.sql
+++ b/src/xmigrate/sql/insert_or_update_subject.sql
@@ -15,10 +15,10 @@ SELECT
     $project,
     $owner_project,
     xnat_id,
-    NULLIF(label, ''),
-    NULLIF(insert_user, ''),
-    NULLIF(insert_date, ''),
-    NULLIF(last_modified, '')
+    NULLIF(label, '') AS lbl,
+    NULLIF(insert_user, '') AS insert_user,
+    NULLIF(insert_date, '') AS insert_date,
+    NULLIF(last_modified, '') AS last_modified
 FROM subject_df
 ON CONFLICT (instance, project, xnat_id) DO UPDATE SET
     label = excluded.label,

--- a/tests/_helper_functions.py
+++ b/tests/_helper_functions.py
@@ -17,6 +17,7 @@ import requests
 import xnat4tests
 
 import xmigrate
+import xmigrate.db
 import xmigrate.migration
 
 if typing.TYPE_CHECKING:
@@ -62,9 +63,12 @@ def delete_data(
             if project.is_dir():
                 shutil.rmtree(project)
 
-    metadata_folder = xmigrate.migration.BASE_OUTPUT_DIR / "localhost"
+    metadata_folder = xmigrate.db.BASE_OUTPUT_DIR / "localhost"
     if metadata_folder.exists():
         shutil.rmtree(str(metadata_folder))
+
+    db_file = xmigrate.db.DB_PATH
+    db_file.unlink(missing_ok=True)
 
 
 def get_roles(connection: xnat.BaseXNATSession, username: str) -> list[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 pytest_plugins = [
     "tests.fixtures.connections",
+    "tests.fixtures.db",
     "tests.fixtures.miscellaneous",
     "tests.fixtures.project_info",
     "tests.fixtures.xnat_config",

--- a/tests/fixtures/db.py
+++ b/tests/fixtures/db.py
@@ -1,0 +1,61 @@
+"""Fixtures for testing the xmigrate.db sub-package."""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+import xmigrate.db as xdb
+from xmigrate.db.helpers import run_sql_template
+
+
+@pytest.fixture
+def db() -> duckdb.DuckDBPyConnection:
+    """Return a fresh in-memory DuckDB connection with the full schema applied."""
+    conn = duckdb.connect(":memory:")
+    run_sql_template(conn, "create_tables.sql")
+    return conn
+
+
+@pytest.fixture
+def source_id(db: duckdb.DuckDBPyConnection) -> int:
+    """Surrogate PK for a source XNAT instance."""
+    return xdb.insert_instance(db, "https://source.xnat.example.com")
+
+
+@pytest.fixture
+def destination_id(db: duckdb.DuckDBPyConnection) -> int:
+    """Surrogate PK for a destination XNAT instance."""
+    return xdb.insert_instance(db, "https://destination.xnat.example.com")
+
+
+@pytest.fixture
+def source_project_id(db: duckdb.DuckDBPyConnection, source_id: int) -> int:
+    """Surrogate PK for a source project."""
+    return xdb.insert_project(db, instance_id=source_id, xnat_id="SRC_PROJ")
+
+
+@pytest.fixture
+def destination_project_id(db: duckdb.DuckDBPyConnection, destination_id: int) -> int:
+    """Surrogate PK for a destination project."""
+    return xdb.insert_project(db, instance_id=destination_id, xnat_id="DEST_PROJ")
+
+
+@pytest.fixture
+def project_id(destination_project_id: int) -> int:
+    """Alias for destination_project_id (backwards compat)."""
+    return destination_project_id
+
+
+@pytest.fixture
+def run_id(
+    db: duckdb.DuckDBPyConnection,
+    source_id: int,
+    destination_id: int,
+) -> int:
+    """Surrogate PK for a migration run."""
+    return xdb.create_migration_run(
+        db,
+        source_instance_id=source_id,
+        destination_instance_id=destination_id,
+    )

--- a/tests/unit/test_db/__init__.py
+++ b/tests/unit/test_db/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the xmigrate.db sub-package."""

--- a/tests/unit/test_db/test_connection.py
+++ b/tests/unit/test_db/test_connection.py
@@ -1,0 +1,46 @@
+"""Tests for xmigrate.db connection and schema helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    import pathlib
+
+import xmigrate.db as xdb
+
+
+class TestOpenDb:
+    """Tests for open_db and load_sql_template."""
+
+    def test_open_db_creates_expected_tables(self, tmp_path: pathlib.Path) -> None:
+        """open_db creates and initialises the schema at the given path."""
+        path = tmp_path / "test.duckdb"
+        with xdb.open_db(path=path) as conn:
+            tables = {row[0] for row in conn.execute("SHOW TABLES").fetchall()}
+        assert {
+            "instance",
+            "project",
+            "subject",
+            "experiment",
+            "map",
+            "migration_run",
+            "migration_run_item",
+            "xnat_user",
+            "user_permission",
+        }.issubset(tables)
+
+    def test_open_db_idempotent(self, tmp_path: pathlib.Path) -> None:
+        """Calling open_db twice on the same file does not raise."""
+        path = tmp_path / "test.duckdb"
+        with xdb.open_db(path=path):
+            pass
+        with xdb.open_db(path=path):
+            pass
+
+    def test_load_sql_template_missing_file_raises(self) -> None:
+        """load_sql_template raises when the template does not exist."""
+        with pytest.raises(FileNotFoundError, match=r"nonexistent_file\.sql"):
+            xdb.load_sql_template("nonexistent_file.sql")

--- a/tests/unit/test_db/test_map.py
+++ b/tests/unit/test_db/test_map.py
@@ -1,0 +1,124 @@
+"""Tests for ID map upsert and query helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import xmigrate.db as xdb
+
+if TYPE_CHECKING:
+    import duckdb
+
+
+class TestUpsertMap:
+    """Tests for insert_map."""
+
+    def test_returns_integer_id(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        source_project_id: int,
+        destination_project_id: int,
+    ) -> None:
+        """insert_map returns an integer surrogate key."""
+        map_id = xdb.insert_map(
+            db,
+            resource_type="subject",
+            source_project_id=source_project_id,
+            destination_project_id=destination_project_id,
+            source_xnat_id="SRC_SUB001",
+            destination_xnat_id="DST_SUB001",
+        )
+        assert isinstance(map_id, int)
+
+    def test_idempotent(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        source_project_id: int,
+        destination_project_id: int,
+    ) -> None:
+        """Calling insert_map twice with the same args returns the same id."""
+        kwargs = {
+            "resource_type": "subject",
+            "source_project_id": source_project_id,
+            "destination_project_id": destination_project_id,
+            "source_xnat_id": "SRC_SUB001",
+            "destination_xnat_id": "DST_SUB001",
+        }
+        id1 = xdb.insert_map(db, **kwargs)
+        id2 = xdb.insert_map(db, **kwargs)
+        assert id1 == id2
+
+    def test_different_resource_types_are_distinct(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        source_project_id: int,
+        destination_project_id: int,
+    ) -> None:
+        """Different resource types with identical XNAT IDs produce distinct keys."""
+        id1 = xdb.insert_map(
+            db,
+            resource_type="subject",
+            source_project_id=source_project_id,
+            destination_project_id=destination_project_id,
+            source_xnat_id="ID001",
+            destination_xnat_id="ID002",
+        )
+        id2 = xdb.insert_map(
+            db,
+            resource_type="experiment",
+            source_project_id=source_project_id,
+            destination_project_id=destination_project_id,
+            source_xnat_id="ID001",
+            destination_xnat_id="ID002",
+        )
+        assert id1 != id2
+
+
+class TestGetIdMap:
+    """Tests for get_id_map."""
+
+    def test_roundtrip(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        source_project_id: int,
+        destination_project_id: int,
+    ) -> None:
+        """Maps inserted via insert_map are returned by get_id_map."""
+        original = {"S1": "D1", "S2": "D2"}
+        kwargs = {
+            "resource_type": "subject",
+            "source_project_id": source_project_id,
+            "destination_project_id": destination_project_id,
+        }
+        for src, dst in original.items():
+            xdb.insert_map(db, **kwargs, source_xnat_id=src, destination_xnat_id=dst)
+        result = xdb.get_id_map(db, "subject", source_project_id, destination_project_id)
+        assert result == original
+
+    def test_empty_when_no_maps(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        source_project_id: int,
+        destination_project_id: int,
+    ) -> None:
+        """get_id_map returns an empty dict when no maps have been inserted."""
+        result = xdb.get_id_map(db, "subject", source_project_id, destination_project_id)
+        assert result == {}
+
+    def test_does_not_return_other_resource_types(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        source_project_id: int,
+        destination_project_id: int,
+    ) -> None:
+        """get_id_map filters by resource type and does not return other types."""
+        xdb.insert_map(
+            db,
+            resource_type="experiment",
+            source_project_id=source_project_id,
+            destination_project_id=destination_project_id,
+            source_xnat_id="E1",
+            destination_xnat_id="E2",
+        )
+        result = xdb.get_id_map(db, "subject", source_project_id, destination_project_id)
+        assert result == {}

--- a/tests/unit/test_db/test_migration_run.py
+++ b/tests/unit/test_db/test_migration_run.py
@@ -83,7 +83,11 @@ class TestRecordMigrationRunItems:
         run_id: int,
     ) -> None:
         """record_migration_run_items links map IDs to the given run."""
-        kwargs = {"resource_type": "subject", "source_project_id": source_project_id, "destination_project_id": destination_project_id}
+        kwargs = {
+            "resource_type": "subject",
+            "source_project_id": source_project_id,
+            "destination_project_id": destination_project_id,
+        }
         map_ids = [
             xdb.insert_map(db, **kwargs, source_xnat_id="S1", destination_xnat_id="D1"),
             xdb.insert_map(db, **kwargs, source_xnat_id="S2", destination_xnat_id="D2"),
@@ -110,14 +114,16 @@ class TestRecordMigrationRunItems:
         run_id: int,
     ) -> None:
         """Calling record_migration_run_items twice with the same ids is idempotent."""
-        map_ids = [xdb.insert_map(
-            db,
-            resource_type="subject",
-            source_project_id=source_project_id,
-            destination_project_id=destination_project_id,
-            source_xnat_id="S1",
-            destination_xnat_id="D1",
-        )]
+        map_ids = [
+            xdb.insert_map(
+                db,
+                resource_type="subject",
+                source_project_id=source_project_id,
+                destination_project_id=destination_project_id,
+                source_xnat_id="S1",
+                destination_xnat_id="D1",
+            )
+        ]
         xdb.record_migration_run_items(db, run_id=run_id, map_ids=map_ids)
         xdb.record_migration_run_items(db, run_id=run_id, map_ids=map_ids)
         count = db.execute("SELECT count(*) FROM migration_run_item WHERE run = ?", [run_id]).fetchone()[0]

--- a/tests/unit/test_db/test_migration_run.py
+++ b/tests/unit/test_db/test_migration_run.py
@@ -1,0 +1,124 @@
+"""Tests for migration run helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import xmigrate.db as xdb
+
+if TYPE_CHECKING:
+    import duckdb
+
+
+class TestCreateMigrationRun:
+    """Tests for create_migration_run."""
+
+    def test_returns_integer_id(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        source_id: int,
+        destination_id: int,
+    ) -> None:
+        """create_migration_run returns an integer surrogate key."""
+        run_id = xdb.create_migration_run(
+            db,
+            source_instance_id=source_id,
+            destination_instance_id=destination_id,
+        )
+        assert isinstance(run_id, int)
+
+    def test_multiple_runs_get_distinct_ids(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        source_id: int,
+        destination_id: int,
+    ) -> None:
+        """Each call to create_migration_run produces a distinct id."""
+        id1 = xdb.create_migration_run(
+            db,
+            source_instance_id=source_id,
+            destination_instance_id=destination_id,
+        )
+        id2 = xdb.create_migration_run(
+            db,
+            source_instance_id=source_id,
+            destination_instance_id=destination_id,
+        )
+        assert id1 != id2
+
+
+class TestCompleteMigrationRun:
+    """Tests for complete_migration_run."""
+
+    def test_complete_sets_completed_at(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        run_id: int,
+    ) -> None:
+        """complete_migration_run sets the completed_at timestamp."""
+        xdb.complete_migration_run(db, run_id)
+        row = db.execute("SELECT completed_at FROM migration_run WHERE id = ?", [run_id]).fetchone()
+        assert row is not None
+        assert row[0] is not None
+
+    def test_completed_at_null_before_completion(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        run_id: int,
+    ) -> None:
+        """completed_at is NULL before complete_migration_run is called."""
+        row = db.execute("SELECT completed_at FROM migration_run WHERE id = ?", [run_id]).fetchone()
+        assert row is not None
+        assert row[0] is None
+
+
+class TestRecordMigrationRunItems:
+    """Tests for record_migration_run_items."""
+
+    def test_links_map_ids_to_run(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        source_project_id: int,
+        destination_project_id: int,
+        run_id: int,
+    ) -> None:
+        """record_migration_run_items links map IDs to the given run."""
+        kwargs = {"resource_type": "subject", "source_project_id": source_project_id, "destination_project_id": destination_project_id}
+        map_ids = [
+            xdb.insert_map(db, **kwargs, source_xnat_id="S1", destination_xnat_id="D1"),
+            xdb.insert_map(db, **kwargs, source_xnat_id="S2", destination_xnat_id="D2"),
+        ]
+        xdb.record_migration_run_items(db, run_id=run_id, map_ids=map_ids)
+        rows = db.execute("SELECT map FROM migration_run_item WHERE run = ?", [run_id]).fetchall()
+        assert {row[0] for row in rows} == set(map_ids)
+
+    def test_empty_map_ids_is_noop(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        run_id: int,
+    ) -> None:
+        """Passing an empty map_ids list inserts no rows."""
+        xdb.record_migration_run_items(db, run_id=run_id, map_ids=[])
+        count = db.execute("SELECT count(*) FROM migration_run_item WHERE run = ?", [run_id]).fetchone()[0]
+        assert count == 0
+
+    def test_idempotent(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        source_project_id: int,
+        destination_project_id: int,
+        run_id: int,
+    ) -> None:
+        """Calling record_migration_run_items twice with the same ids is idempotent."""
+        map_ids = [xdb.insert_map(
+            db,
+            resource_type="subject",
+            source_project_id=source_project_id,
+            destination_project_id=destination_project_id,
+            source_xnat_id="S1",
+            destination_xnat_id="D1",
+        )]
+        xdb.record_migration_run_items(db, run_id=run_id, map_ids=map_ids)
+        xdb.record_migration_run_items(db, run_id=run_id, map_ids=map_ids)
+        count = db.execute("SELECT count(*) FROM migration_run_item WHERE run = ?", [run_id]).fetchone()[0]
+        assert count == 1

--- a/tests/unit/test_db/test_resource_upsert.py
+++ b/tests/unit/test_db/test_resource_upsert.py
@@ -1,0 +1,216 @@
+"""Tests for instance, project, subject and experiment upsert helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+import xmigrate.db as xdb
+
+if TYPE_CHECKING:
+    import duckdb
+
+
+class TestInsertInstance:
+    """Tests for insert_instance."""
+
+    def test_returns_integer_id(self, db: duckdb.DuckDBPyConnection) -> None:
+        """insert_instance returns an integer surrogate key."""
+        instance_id = xdb.insert_instance(db, "https://xnat.example.com")
+        assert isinstance(instance_id, int)
+
+    def test_idempotent(self, db: duckdb.DuckDBPyConnection) -> None:
+        """Calling insert_instance twice with the same URL returns the same id."""
+        id1 = xdb.insert_instance(db, "https://xnat.example.com")
+        id2 = xdb.insert_instance(db, "https://xnat.example.com")
+        assert id1 == id2
+
+    def test_different_urls_different_ids(self, db: duckdb.DuckDBPyConnection) -> None:
+        """Different URLs produce distinct surrogate keys."""
+        id1 = xdb.insert_instance(db, "https://xnat-a.example.com")
+        id2 = xdb.insert_instance(db, "https://xnat-b.example.com")
+        assert id1 != id2
+
+    def test_parses_port(self, db: duckdb.DuckDBPyConnection) -> None:
+        """insert_instance does not raise when a non-standard port is present."""
+        xdb.insert_instance(db, "http://xnat.example.com:8080")
+
+
+class TestInsertProject:
+    """Tests for insert_project."""
+
+    def test_returns_integer_id(self, db: duckdb.DuckDBPyConnection, destination_id: int) -> None:
+        """insert_project returns an integer surrogate key."""
+        project_id = xdb.insert_project(db, instance_id=destination_id, xnat_id="PROJ1")
+        assert isinstance(project_id, int)
+
+    def test_idempotent(self, db: duckdb.DuckDBPyConnection, destination_id: int) -> None:
+        """Calling insert_project twice with the same args returns the same id."""
+        id1 = xdb.insert_project(db, instance_id=destination_id, xnat_id="PROJ1")
+        id2 = xdb.insert_project(db, instance_id=destination_id, xnat_id="PROJ1")
+        assert id1 == id2
+
+    def test_same_xnat_id_different_instances_are_distinct(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        source_id: int,
+        destination_id: int,
+    ) -> None:
+        """The same XNAT project ID on different instances yields distinct keys."""
+        id1 = xdb.insert_project(db, instance_id=source_id, xnat_id="PROJ1")
+        id2 = xdb.insert_project(db, instance_id=destination_id, xnat_id="PROJ1")
+        assert id1 != id2
+
+    def test_optional_fields_accepted(self, db: duckdb.DuckDBPyConnection, destination_id: int) -> None:
+        """Optional keyword arguments are accepted without error."""
+        xdb.insert_project(
+            db,
+            instance_id=destination_id,
+            xnat_id="PROJ2",
+            secondary_id="SEC2",
+        )
+
+
+class TestUpsertSubject:
+    """Tests for upsert_subject."""
+
+    def _make_df(self, xnat_id: str = "SUB001", **kwargs) -> pd.DataFrame:
+        row = {"xnat_id": xnat_id, "label": None, "insert_user": None, "insert_date": None, "last_modified": None}
+        row.update(kwargs)
+        return pd.DataFrame([row])
+
+    def test_does_not_raise(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        destination_id: int,
+        project_id: int,
+    ) -> None:
+        """upsert_subject does not raise for a valid DataFrame."""
+        xdb.upsert_subject(
+            db,
+            instance_id=destination_id,
+            project_id=project_id,
+            owner_project_id=project_id,
+            df=self._make_df(),
+        )
+
+    def test_idempotent(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        destination_id: int,
+        project_id: int,
+    ) -> None:
+        """Calling upsert_subject twice with the same DataFrame does not raise."""
+        kwargs = {
+            "instance_id": destination_id,
+            "project_id": project_id,
+            "owner_project_id": project_id,
+            "df": self._make_df(),
+        }
+        xdb.upsert_subject(db, **kwargs)
+        xdb.upsert_subject(db, **kwargs)
+
+    def test_bulk_insert(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        destination_id: int,
+        project_id: int,
+    ) -> None:
+        """upsert_subject inserts multiple rows from a single DataFrame."""
+        df = pd.DataFrame([
+            {"xnat_id": "SUB001", "label": "Sub 1", "insert_user": None, "insert_date": None, "last_modified": None},
+            {"xnat_id": "SUB002", "label": "Sub 2", "insert_user": None, "insert_date": None, "last_modified": None},
+        ])
+        xdb.upsert_subject(
+            db,
+            instance_id=destination_id,
+            project_id=project_id,
+            owner_project_id=project_id,
+            df=df,
+        )
+
+    def test_null_metadata_accepted(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        destination_id: int,
+        project_id: int,
+    ) -> None:
+        """None values for optional metadata columns should not raise."""
+        xdb.upsert_subject(
+            db,
+            instance_id=destination_id,
+            project_id=project_id,
+            owner_project_id=project_id,
+            df=self._make_df(label=None, insert_user=None, insert_date=None, last_modified=None),
+        )
+
+
+class TestUpsertExperiment:
+    """Tests for upsert_experiment."""
+
+    def _make_df(self, xnat_id: str = "EXP001", **kwargs) -> pd.DataFrame:
+        row = {"xnat_id": xnat_id, "label": None, "insert_user": None, "insert_date": None, "last_modified": None}
+        row.update(kwargs)
+        return pd.DataFrame([row])
+
+    def test_does_not_raise(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        destination_id: int,
+        project_id: int,
+    ) -> None:
+        """upsert_experiment does not raise for a valid DataFrame."""
+        xdb.upsert_experiment(
+            db,
+            instance_id=destination_id,
+            project_id=project_id,
+            df=self._make_df(),
+        )
+
+    def test_idempotent(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        destination_id: int,
+        project_id: int,
+    ) -> None:
+        """Calling upsert_experiment twice with the same DataFrame does not raise."""
+        kwargs = {
+            "instance_id": destination_id,
+            "project_id": project_id,
+            "df": self._make_df(),
+        }
+        xdb.upsert_experiment(db, **kwargs)
+        xdb.upsert_experiment(db, **kwargs)
+
+    def test_bulk_insert(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        destination_id: int,
+        project_id: int,
+    ) -> None:
+        """upsert_experiment inserts multiple rows from a single DataFrame."""
+        df = pd.DataFrame([
+            {"xnat_id": "EXP001", "label": "Exp 1", "insert_user": None, "insert_date": None, "last_modified": None},
+            {"xnat_id": "EXP002", "label": "Exp 2", "insert_user": None, "insert_date": None, "last_modified": None},
+        ])
+        xdb.upsert_experiment(
+            db,
+            instance_id=destination_id,
+            project_id=project_id,
+            df=df,
+        )
+
+    def test_null_metadata_accepted(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        destination_id: int,
+        project_id: int,
+    ) -> None:
+        """None values for optional metadata columns should not raise."""
+        xdb.upsert_experiment(
+            db,
+            instance_id=destination_id,
+            project_id=project_id,
+            df=self._make_df(label=None, insert_user=None, insert_date=None, last_modified=None),
+        )

--- a/tests/unit/test_db/test_resource_upsert.py
+++ b/tests/unit/test_db/test_resource_upsert.py
@@ -75,7 +75,7 @@ class TestInsertProject:
 class TestUpsertSubject:
     """Tests for upsert_subject."""
 
-    def _make_df(self, xnat_id: str = "SUB001", **kwargs) -> pd.DataFrame:
+    def _make_df(self, xnat_id: str = "SUB001", **kwargs: str | None) -> pd.DataFrame:
         row = {"xnat_id": xnat_id, "label": None, "insert_user": None, "insert_date": None, "last_modified": None}
         row.update(kwargs)
         return pd.DataFrame([row])
@@ -118,10 +118,24 @@ class TestUpsertSubject:
         project_id: int,
     ) -> None:
         """upsert_subject inserts multiple rows from a single DataFrame."""
-        df = pd.DataFrame([
-            {"xnat_id": "SUB001", "label": "Sub 1", "insert_user": None, "insert_date": None, "last_modified": None},
-            {"xnat_id": "SUB002", "label": "Sub 2", "insert_user": None, "insert_date": None, "last_modified": None},
-        ])
+        df = pd.DataFrame(
+            [
+                {
+                    "xnat_id": "SUB001",
+                    "label": "Sub 1",
+                    "insert_user": None,
+                    "insert_date": None,
+                    "last_modified": None,
+                },
+                {
+                    "xnat_id": "SUB002",
+                    "label": "Sub 2",
+                    "insert_user": None,
+                    "insert_date": None,
+                    "last_modified": None,
+                },
+            ]
+        )
         xdb.upsert_subject(
             db,
             instance_id=destination_id,
@@ -149,7 +163,7 @@ class TestUpsertSubject:
 class TestUpsertExperiment:
     """Tests for upsert_experiment."""
 
-    def _make_df(self, xnat_id: str = "EXP001", **kwargs) -> pd.DataFrame:
+    def _make_df(self, xnat_id: str = "EXP001", **kwargs: str | None) -> pd.DataFrame:
         row = {"xnat_id": xnat_id, "label": None, "insert_user": None, "insert_date": None, "last_modified": None}
         row.update(kwargs)
         return pd.DataFrame([row])
@@ -190,10 +204,24 @@ class TestUpsertExperiment:
         project_id: int,
     ) -> None:
         """upsert_experiment inserts multiple rows from a single DataFrame."""
-        df = pd.DataFrame([
-            {"xnat_id": "EXP001", "label": "Exp 1", "insert_user": None, "insert_date": None, "last_modified": None},
-            {"xnat_id": "EXP002", "label": "Exp 2", "insert_user": None, "insert_date": None, "last_modified": None},
-        ])
+        df = pd.DataFrame(
+            [
+                {
+                    "xnat_id": "EXP001",
+                    "label": "Exp 1",
+                    "insert_user": None,
+                    "insert_date": None,
+                    "last_modified": None,
+                },
+                {
+                    "xnat_id": "EXP002",
+                    "label": "Exp 2",
+                    "insert_user": None,
+                    "insert_date": None,
+                    "last_modified": None,
+                },
+            ]
+        )
         xdb.upsert_experiment(
             db,
             instance_id=destination_id,

--- a/tests/unit/test_db/test_user.py
+++ b/tests/unit/test_db/test_user.py
@@ -1,0 +1,124 @@
+"""Tests for user and user-permission helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import xmigrate.db as xdb
+
+if TYPE_CHECKING:
+    import duckdb
+
+
+class TestUpsertUser:
+    """Tests for upsert_user."""
+
+    def test_returns_integer_id(self, db: duckdb.DuckDBPyConnection, destination_id: int) -> None:
+        """upsert_user returns an integer surrogate key."""
+        user_id = xdb.upsert_user(db, instance_id=destination_id, login="alice")
+        assert isinstance(user_id, int)
+
+    def test_idempotent(self, db: duckdb.DuckDBPyConnection, destination_id: int) -> None:
+        """Calling upsert_user twice with the same login returns the same id."""
+        id1 = xdb.upsert_user(db, instance_id=destination_id, login="alice")
+        id2 = xdb.upsert_user(db, instance_id=destination_id, login="alice")
+        assert id1 == id2
+
+    def test_different_logins_different_ids(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        destination_id: int,
+    ) -> None:
+        """Different logins on the same instance produce distinct surrogate keys."""
+        id1 = xdb.upsert_user(db, instance_id=destination_id, login="alice")
+        id2 = xdb.upsert_user(db, instance_id=destination_id, login="bob")
+        assert id1 != id2
+
+    def test_optional_fields_accepted(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        destination_id: int,
+    ) -> None:
+        """Optional keyword arguments are accepted without error."""
+        xdb.upsert_user(
+            db,
+            instance_id=destination_id,
+            login="alice",
+            firstname="Alice",
+            lastname="Smith",
+            email="alice@example.com",
+        )
+
+
+class TestUpsertUserPermission:
+    """Tests for upsert_user_permission."""
+
+    def test_no_error_on_insert(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        destination_id: int,
+        project_id: int,
+        run_id: int,
+    ) -> None:
+        """upsert_user_permission does not raise on a valid insert."""
+        user_id = xdb.upsert_user(db, instance_id=destination_id, login="alice")
+        xdb.upsert_user_permission(
+            db,
+            instance_id=destination_id,
+            project_id=project_id,
+            user_id=user_id,
+            displayname="Collaborator",
+            run_id=run_id,
+        )
+
+    def test_idempotent(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        destination_id: int,
+        project_id: int,
+        run_id: int,
+    ) -> None:
+        """Calling upsert_user_permission twice with the same args does not raise."""
+        user_id = xdb.upsert_user(db, instance_id=destination_id, login="alice")
+        kwargs = {
+            "instance_id": destination_id,
+            "project_id": project_id,
+            "user_id": user_id,
+            "displayname": "Collaborator",
+            "run_id": run_id,
+        }
+        xdb.upsert_user_permission(db, **kwargs)
+        xdb.upsert_user_permission(db, **kwargs)
+
+
+class TestGetUserPermissionsForProject:
+    """Tests for get_user_permissions_for_project."""
+
+    def test_empty_before_any_insert(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        project_id: int,
+    ) -> None:
+        """Returns an empty list when no permissions have been inserted."""
+        result = xdb.get_user_permissions_for_project(db, project_id)
+        assert result == []
+
+    def test_returns_permissions_after_insert(
+        self,
+        db: duckdb.DuckDBPyConnection,
+        destination_id: int,
+        project_id: int,
+        run_id: int,
+    ) -> None:
+        """Returns inserted permissions for the given project."""
+        user_id = xdb.upsert_user(db, instance_id=destination_id, login="alice")
+        xdb.upsert_user_permission(
+            db,
+            instance_id=destination_id,
+            project_id=project_id,
+            user_id=user_id,
+            displayname="Collaborator",
+            run_id=run_id,
+        )
+        result = xdb.get_user_permissions_for_project(db, project_id)
+        assert len(result) == 1

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -37,14 +37,26 @@ def test_check_users_source_longer(
     source_profiles = [source_profile_unique, source_profile_second]
 
     with caplog.at_level(logging.INFO):
-        xmigrate.check_user(unique_username, source_profiles, [destination_profiles], destination_connection)
+        returned_profiles = xmigrate.check_user(
+            unique_username,
+            source_profiles,
+            [destination_profiles],
+            destination_connection,
+        )
     assert any(record.message == f"User already exists in destination: {unique_username}" for record in caplog.records)
+    assert returned_profiles is None
     assert second_username not in get_usernames(destination_connection)
 
     with caplog.at_level(logging.INFO):
-        xmigrate.check_user(second_username, source_profiles, [destination_profiles], destination_connection)
+        returned_profiles = xmigrate.check_user(
+            second_username,
+            source_profiles,
+            [destination_profiles],
+            destination_connection,
+        )
     assert any(record.message == f"Creating user: {second_username}" for record in caplog.records)
     assert second_username in get_usernames(destination_connection)
+    assert any(p["username"] == second_username for p in returned_profiles)
 
 
 def test_creates_missing_users(
@@ -59,9 +71,15 @@ def test_creates_missing_users(
     assert unique_username not in get_usernames(destination_connection)
 
     with caplog.at_level(logging.INFO):
-        xmigrate.check_user(unique_username, [source_profiles], [], destination_connection)
+        returned_profiles = xmigrate.check_user(
+            unique_username,
+            [source_profiles],
+            [],
+            destination_connection,
+        )
     assert any(record.message == f"Creating user: {unique_username}" for record in caplog.records)
     assert unique_username in get_usernames(destination_connection)
+    assert any(p["username"] == unique_username for p in returned_profiles)
 
 
 def test_creates_missing_users_roles(
@@ -74,19 +92,14 @@ def test_creates_missing_users_roles(
     roles = ("user", "data_manager")
     seed_user(source_connection, unique_username, roles=roles)
     seed_user(destination_connection, unique_username, roles=roles)
-    folder_path = xmigrate.migration.BASE_OUTPUT_DIR / "localhost"
-    xmigrate.check_user_roles(
+    updated_roles = xmigrate.check_user_roles(
         unique_username,
-        folder_path,
         migration.sitewide_roles,
-        destination_connection,
         source_connection,
+        destination_connection,
     )
     assert "data_manager" in get_roles(destination_connection, unique_username)
-    assert set(migration.sitewide_roles[unique_username]) == set(roles)
-
-    checkpoint_file = folder_path / "sitewide_roles.json"
-    assert checkpoint_file.exists()
+    assert set(updated_roles[unique_username]) == set(roles)
 
 
 def test_roles_skipped_if_checkpoint_exists(
@@ -100,28 +113,24 @@ def test_roles_skipped_if_checkpoint_exists(
     roles = ("user", "data_manager")
     seed_user(source_connection, unique_username, roles=roles)
     seed_user(destination_connection, unique_username, roles=roles)
-    folder_path = xmigrate.migration.BASE_OUTPUT_DIR / "localhost"
-    xmigrate.check_user_roles(
+    updated_roles = xmigrate.check_user_roles(
         unique_username,
-        folder_path,
         migration.sitewide_roles,
-        destination_connection,
         source_connection,
+        destination_connection,
     )
-    checkpoint_file = folder_path / "sitewide_roles.json"
-    assert checkpoint_file.exists()
 
     with caplog.at_level(logging.INFO):
-        xmigrate.check_user_roles(
+        updated_roles = xmigrate.check_user_roles(
             unique_username,
-            folder_path,
-            migration.sitewide_roles,
-            destination_connection,
+            updated_roles,
             source_connection,
+            destination_connection,
         )
     assert any(
         record.message == f"User roles already exist in destination: {unique_username}" for record in caplog.records
     )
+    assert set(updated_roles[unique_username]) == set(roles)
 
 
 def test_existing_users_not_duplicated(
@@ -135,8 +144,11 @@ def test_existing_users_not_duplicated(
     destination_profiles = seed_user(destination_connection, unique_username)
 
     with caplog.at_level(logging.INFO):
-        xmigrate.check_user(unique_username, [source_profiles], [destination_profiles], destination_connection)
+        returned_profiles = xmigrate.check_user(
+            unique_username, [source_profiles], [destination_profiles], destination_connection
+        )
     assert any(record.message == f"User already exists in destination: {unique_username}" for record in caplog.records)
+    assert returned_profiles is None
     user_count = sum(u == unique_username for u in get_usernames(destination_connection))
     assert user_count == 1
 
@@ -154,11 +166,15 @@ def test_creates_multiple_users(
     source_profiles = [source_profile_unique, source_profile_second]
 
     with caplog.at_level(logging.INFO):
-        xmigrate.check_user(unique_username, source_profiles, [], destination_connection)
+        returned_profiles = xmigrate.check_user(unique_username, source_profiles, [], destination_connection)
     assert any(record.message == f"Creating user: {unique_username}" for record in caplog.records)
     assert unique_username in get_usernames(destination_connection)
+    assert any(p["username"] == unique_username for p in returned_profiles)
 
     with caplog.at_level(logging.INFO):
-        xmigrate.check_user(second_username, source_profiles, [source_profile_unique], destination_connection)
+        returned_profiles = xmigrate.check_user(
+            second_username, source_profiles, [source_profile_unique], destination_connection
+        )
     assert any(record.message == f"Creating user: {second_username}" for record in caplog.records)
     assert second_username in get_usernames(destination_connection)
+    assert any(p["username"] == second_username for p in returned_profiles)


### PR DESCRIPTION
Closes #96 
Depends on #161 

- add unit tests for the varaious `xmigrat.db` modules 
- update the `delete_data` test helper to also delete the test db file