### PR TITLE
Fix integration tests

### DIFF
--- a/tests/integration/test_migration.py
+++ b/tests/integration/test_migration.py
@@ -210,4 +210,5 @@ class TestMigration:
         destination_response = destination_connection.get(f"/data/projects/{project_id}/{resource}", query=params)
         destination_result = destination_response.json()["ResultSet"]["Result"]
 
-        assert set(source_result) == set(destination_result)
+        # Results are returned in an arbitrary order, so we compare them as sets of frozensets to ignore the ordering
+        assert {frozenset(d.items()) for d in source_result} == {frozenset(d.items()) for d in destination_result}

--- a/tests/integration/test_migration.py
+++ b/tests/integration/test_migration.py
@@ -210,4 +210,4 @@ class TestMigration:
         destination_response = destination_connection.get(f"/data/projects/{project_id}/{resource}", query=params)
         destination_result = destination_response.json()["ResultSet"]["Result"]
 
-        assert source_result == destination_result
+        assert set(source_result) == set(destination_result)


### PR DESCRIPTION
Integration tests have been intermittently failing since merging https://github.com/UCL-MIRSG/xmigrate/pull/150

Compare the projects the subjects are shared into as sets rather than lists. This is because the returned order is not deterministic