### PR TITLE
Hotfixes implemented while testing migration using xmigrate-configs

### DIFF
--- a/src/xmigrate/custom_forms.py
+++ b/src/xmigrate/custom_forms.py
@@ -10,7 +10,7 @@ from xnat.exceptions import XNATResponseError
 LOGGER = logging.getLogger(__name__)
 
 
-def create_custom_forms_json(  # noqa: PLR0915
+def create_custom_forms_json(
     source_connection: xnat.BaseXNATSession,
     destination_connection: xnat.BaseXNATSession,
 ) -> None:
@@ -30,107 +30,90 @@ def create_custom_forms_json(  # noqa: PLR0915
         If failed to create custom forms on destination.
 
     """
-    # Get custom forms from source as json
     source_custom_forms = source_connection.get_json("/xapi/customforms")
     destination_custom_forms = destination_connection.get_json("/xapi/customforms")
 
-    source_titles = []
-    destination_titles = []
-    for source_custom_form, destination_custom_form in zip(
-        source_custom_forms,
-        destination_custom_forms,
-        strict=False,
-    ):
-        source_obj = json.loads(source_custom_form["contents"])
-        source_title = source_obj["title"]
-        destination_obj = json.loads(destination_custom_form["contents"])
-        destination_title = destination_obj["title"]
-        source_titles.append(source_title)
-        destination_titles.append(destination_title)
+    destination_titles = {
+        json.loads(destination_form["contents"])["title"] for destination_form in destination_custom_forms
+    }
 
-    source_titles.sort()
-    destination_titles.sort()
-    if source_titles == destination_titles:
-        LOGGER.info("Customs form already exist on destination so no need to migrate them.")
+    forms_to_create = [
+        source_form
+        for source_form in source_custom_forms
+        if json.loads(source_form["contents"])["title"] not in destination_titles
+    ]
+
+    if not forms_to_create:
+        LOGGER.info("Custom forms already exist on destination so no need to migrate them.")
         return
 
-    LOGGER.info("There are %d custom forms being created", len(source_custom_forms))
+    LOGGER.info("There are %d custom forms being created", len(forms_to_create))
 
-    # Loop through custom forms
-    for _form_idx, source_custom_form in enumerate(source_custom_forms):
-        # Create empty submission object
+    for source_custom_form in forms_to_create:
         current_submission = {
             "submission": {
                 "data": {
                     "zIndex": [],
                     "xnatDatatype": {"label": [], "value": []},
                     "isThisASiteWideConfiguration": [],
-                    "xnatProject": [{"label": [], "value": []}],
+                    "xnatProject": [{"label": "", "value": ""}],
                 },
             },
         }
 
-        # Extract projects list, datatype, scope and formDisplayOrder
         projects = source_custom_form["appliesToList"]
         datatype = source_custom_form["path"]
         datatype_value = datatype.replace("datatype/", "")
         scope = source_custom_form["scope"]
         zindex = source_custom_form["formDisplayOrder"]
 
-        # Populate zIndex and isThisASiteWideConfiguration
         current_submission["submission"]["data"]["zIndex"] = zindex
+
         if scope == "Site":
             current_submission["submission"]["data"]["isThisASiteWideConfiguration"] = "yes"
-            projects = []
-            # fetch projects response and build list of IDs
+
             destination_projects_resp = destination_connection.get("/data/projects").json()
             projects = [project["ID"] for project in destination_projects_resp["ResultSet"]["Result"]]
-
         else:
             current_submission["submission"]["data"]["isThisASiteWideConfiguration"] = "no"
 
-        # Populate datatype section of submission object
-        xnat_datatype_dict: dict[str, str] = {"label": datatype, "value": datatype_value}
+        current_submission["submission"]["data"]["xnatDatatype"] = {
+            "label": datatype,
+            "value": datatype_value,
+        }
 
-        current_submission["submission"]["data"]["xnatDatatype"] = xnat_datatype_dict
+        xnat_project_list: list[dict[str, str]] = []
 
-        # Loop through projects to populate project section of submission object
-        current_dict: dict[str, str] = {}
-        xnat_project_list: list[dict[str, str]] = [{"label": "", "value": ""}]
-        for proj_idx, project in enumerate(projects):
+        for project in projects:
             current_proj = project if scope == "Site" else project["entityId"]
 
-            # Initially populate empty project section and then append
-            if proj_idx == 0:
-                xnat_project_list[proj_idx]["label"] = current_proj
-                xnat_project_list[proj_idx]["value"] = current_proj
-
-            else:
-                current_dict = {"label": current_proj, "value": current_proj}
-                xnat_project_list.append(current_dict)
+            xnat_project_list.append(
+                {
+                    "label": current_proj,
+                    "value": current_proj,
+                },
+            )
 
         current_submission["submission"]["data"]["xnatProject"] = xnat_project_list
 
-        # Extract contents of form, convert to dict and create builder_dict
         current_custom_form = source_custom_form["contents"]
         current_custom_form_dict = json.loads(current_custom_form)
-        builder_dict = {"builder": current_custom_form_dict}
 
-        # Construct current custom forms dict with submission and builder components
-        current_submission |= builder_dict
+        current_submission["builder"] = current_custom_form_dict
 
-        # Convert to current custom forms to json formatted string
         current_custom_form_json = json.dumps(current_submission)
 
-        # Try a PUT API call to save the current custom form on the destination
-        current_content_json = json.loads(current_custom_form)
-        title = current_content_json["title"]
+        title = current_custom_form_dict["title"]
+
         try:
             headers = {"Content-Type": "application/json;charset=UTF-8"}
-            destination_connection.put("/xapi/customforms/save", data=current_custom_form_json, headers=headers)
+            destination_connection.put(
+                "/xapi/customforms/save",
+                data=current_custom_form_json,
+                headers=headers,
+            )
         except XNATResponseError as e:
             msg = f"Failed to create the {title} custom form on destination XNAT\n: {e.text}"
             raise RuntimeError(msg) from e
 
-        msg = f"The {title} custom form has been successfully created"
-        LOGGER.info(msg)
+        LOGGER.info("The %s custom form has been successfully created", title)

--- a/src/xmigrate/migration.py
+++ b/src/xmigrate/migration.py
@@ -500,15 +500,26 @@ class Migration:
         if owner_project != self.source_info.id:
             requested_projects = {info.id for info in self.all_source_info}
 
-            if owner_project not in requested_projects:
-                msg = f"Cannot migrate subject {subject.label!r} in project {self.source_info.id!r}: "
-                f"it is owned by project {owner_project!r}, which is not included in this migration. "
-                f"Migrate {owner_project!r} first, include it in the same migration run, or rerun with."
+            owner_in_current_run = owner_project in requested_projects
+            owner_exists_on_destination = (
+                owner_project in self.destination_connection.projects
+                and subject.label in self.destination_connection.projects[owner_project].subjects
+            )
+
+            if not owner_in_current_run and not owner_exists_on_destination:
+                msg = (
+                    f"Cannot migrate subject {subject.label!r} in project {self.source_info.id!r}: "
+                    f"it is owned by project {owner_project!r}, which is not included in this migration. "
+                    f"and does not already exist on the destination. "
+                    f"Migrate {owner_project!r} first, include it in the same migration run, or rerun with the owner project included."
+                )
                 raise RuntimeError(msg)
 
             # this project is not the owner of the resource, no need to create it on the destination
             sharing_info["projects"].append(self.destination_info.id)
             sharing_info["source_id"] = subject.id  # Store the source ID
+            sharing_info["owner"] = owner_project
+            sharing_info["label"] = subject.label
             self.subject_sharing[subject.label] = sharing_info
             return
         # otherwise, this project is the owner

--- a/src/xmigrate/migration.py
+++ b/src/xmigrate/migration.py
@@ -938,13 +938,13 @@ class Migration:
         for subject in source_project.subjects:
             self._create_subject(subject)
 
-            # Skip resource creation for this subject if it is shared and this project is not the owner
-            sharing_info = self.subject_sharing[subject.label]
-            if sharing_info["owner"] != self.destination_info.id:
-                continue
+            subject_sharing_info = self.subject_sharing[subject.label]
+            subject_is_shared = subject_sharing_info["owner"] != self.destination_info.id
 
             for experiment in subject.experiments:
                 self._create_experiment(experiment, destination_datatypes)
+                if subject_is_shared:
+                    continue
                 for scan in experiment.scans:
                     self._create_scan(scan)
                 for assessor in experiment.assessors:

--- a/src/xmigrate/migration.py
+++ b/src/xmigrate/migration.py
@@ -774,7 +774,7 @@ class Migration:
         )
 
         # _collect_sharing_info
-        sharing_info = self.assessor_sharing.get(assessor.label, {"owner": None, "projects": []})
+        sharing_info = self.assessor_sharing.get(assessor.id, {"owner": None, "projects": []})
         if root.attrib["project"] != self.source_info.id:
             # this project is not the owner of the resource, no need to create it on the destination
             owner_project = root.attrib["project"]

--- a/src/xmigrate/migration.py
+++ b/src/xmigrate/migration.py
@@ -123,28 +123,29 @@ class Migration:
             If the destination XNAT returns an invalid response.
 
         """
-        # If a project has no custom configuration, XNAT raises an error
         try:
-            custom_configs = self.source_connection.get(f"/data/projects/{self.source_info.id}/config").json()[
-                "ResultSet"
-            ]["Result"]
+            custom_configs = self.source_connection.get(
+                f"/data/projects/{self.source_info.id}/config",
+            ).json()["ResultSet"]["Result"]
         except XNATResponseError as e:
             if "Couldn't find config for" in e.text:
-                msg = f"No custom project configuration found for project {self.source_info.id}."
-                LOGGER.info(msg)
+                LOGGER.info("No custom project configuration found for project %s.", self.source_info.id)
                 return
             msg = f"Invalid response from XNAT\n: {e.text}"
             raise RuntimeError(msg) from e
 
         tools = [config["tool"] for config in custom_configs]
+
         for tool in tools:
-            tool_configs = self.source_connection.get(f"/data/projects/{self.source_info.id}/config/{tool}").json()[
-                "ResultSet"
-            ]["Result"]
-            # There is one result per setting in the config
+            tool_configs = self.source_connection.get(
+                f"/data/projects/{self.source_info.id}/config/{tool}",
+            ).json()["ResultSet"]["Result"]
+
             for tool_config_result in tool_configs:
-                path = tool_config_result["path"]  # name of the setting
+                path = tool_config_result["path"].lstrip("/")
+                path = path.replace(self.source_info.id, self.destination_info.id)
                 contents = tool_config_result["contents"]
+
                 try:
                     self.destination_connection.put(
                         f"/data/projects/{self.destination_info.id}/config/{tool}/{path}",

--- a/src/xmigrate/migration.py
+++ b/src/xmigrate/migration.py
@@ -1234,6 +1234,7 @@ class Migration:
         db_path = xdb.DB_PATH
 
         try:
+            LOGGER.info("Using xmigrate DuckDB state file: %s", db_path)
             with xdb.open_db() as self._xmigrate_connection:
                 self._xmigrate_ids = self._get_run_ids()
                 try:
@@ -1245,14 +1246,19 @@ class Migration:
                     )
 
         except Exception:
-            if db_path.exists():
-                failed_dir = db_path.parent / "logs" / "failed-duckdb"
-                failed_dir.mkdir(parents=True, exist_ok=True)
+            LOGGER.exception("Migration failed")
 
-                failed_path = failed_dir / f"xmigrate.duckdb.failed.{time.strftime('%Y%m%d_%H%M%S')}"
+            if db_path.exists():
+                logs_dir = db_path.parent / "logs"
+                logs_dir.mkdir(exist_ok=True)
+
+                failed_path = logs_dir / f"xmigrate.duckdb.failed.{time.strftime('%Y%m%d_%H%M%S')}"
                 shutil.move(str(db_path), str(failed_path))
 
-                LOGGER.exception("Migration failed; moved xmigrate DuckDB state to %s", failed_path)
+                LOGGER.info("Moved xmigrate DuckDB state to %s", failed_path)
+            else:
+                LOGGER.warning("Expected DuckDB state file does not exist: %s", db_path)
+
             raise
 
         end = time.time()

--- a/src/xmigrate/migration.py
+++ b/src/xmigrate/migration.py
@@ -3,6 +3,7 @@
 import dataclasses
 import json
 import logging
+import shutil
 import time
 import xml.etree.ElementTree as ET
 from typing import TYPE_CHECKING
@@ -1219,13 +1220,29 @@ class Migration:
         check_datatypes_matching(self.source_connection, self.destination_connection)
         create_custom_forms_json(self.source_connection, self.destination_connection)
 
-        with xdb.open_db() as self._xmigrate_connection:
-            self._xmigrate_ids = self._get_run_ids()
-            try:
-                self._run()
-            finally:
-                xdb.complete_migration_run(self._xmigrate_connection, self._xmigrate_ids.migration_run)
+        db_path = xdb.DB_PATH
+
+        try:
+            with xdb.open_db() as self._xmigrate_connection:
+                self._xmigrate_ids = self._get_run_ids()
+                try:
+                    self._run()
+                finally:
+                    xdb.complete_migration_run(
+                        self._xmigrate_connection,
+                        self._xmigrate_ids.migration_run,
+                    )
+
+        except Exception:
+            if db_path.exists():
+                failed_dir = db_path.parent / "logs" / "failed-duckdb"
+                failed_dir.mkdir(parents=True, exist_ok=True)
+
+                failed_path = failed_dir / f"xmigrate.duckdb.failed.{time.strftime('%Y%m%d_%H%M%S')}"
+                shutil.move(str(db_path), str(failed_path))
+
+                LOGGER.exception("Migration failed; moved xmigrate DuckDB state to %s", failed_path)
+            raise
 
         end = time.time()
-
         LOGGER.info("Duration = %d", end - start)

--- a/src/xmigrate/migration.py
+++ b/src/xmigrate/migration.py
@@ -750,7 +750,7 @@ class Migration:
 
         self._create_custom_forms_data(scan)
 
-    def _create_assessor(self, assessor: xnat.core.XNATListing) -> None:
+    def _create_assessor(self, assessor: xnat.core.XNATListing) -> None:  # noqa: PLR0915
         """
         Create an assessor on the destination XNAT instance.
 
@@ -774,13 +774,20 @@ class Migration:
         )
 
         # _collect_sharing_info
-        sharing_info = self.assessor_sharing.get(assessor.id, {"owner": None, "projects": []})
+        sharing_info = self.assessor_sharing.get(assessor.label, {"owner": None, "projects": []})
         if root.attrib["project"] != self.source_info.id:
             # this project is not the owner of the resource, no need to create it on the destination
-            sharing_info["projects"].append(self.destination_info.id)
+            owner_project = root.attrib["project"]
+            sharing_info["owner"] = owner_project
+            sharing_info["label"] = assessor.label
             sharing_info["source_id"] = assessor.id  # Store the source ID
+
+            if self.destination_info.id not in sharing_info["projects"]:
+                sharing_info["projects"].append(self.destination_info.id)
+
             self.assessor_sharing[assessor.label] = sharing_info
             return
+
         # otherwise, this project is the owner
         sharing_info["owner"] = self.destination_info.id
         sharing_info["label"] = assessor.label
@@ -802,43 +809,50 @@ class Migration:
             resource_type=XnatType.assessor,
         )
         xml_bytes = ET.tostring(root, encoding="utf-8")
-        if (
-            assessor.label
-            not in self.destination_connection.projects[self.destination_info.id]
+
+        destination_experiment = (
+            self.destination_connection.projects[self.destination_info.id]
             .subjects[subject.label]
             .experiments[experiment.label]
-            .assessors
-        ):
+        )
+
+        existing_assessors = self.destination_connection.get(
+            f"/data/experiments/{destination_experiment.id}/assessors",
+            query={"format": "json"},
+        ).json()["ResultSet"]["Result"]
+
+        existing_by_label = {existing_assessor["label"]: existing_assessor["ID"] for existing_assessor in existing_assessors}
+
+        if assessor.label not in existing_by_label:
             self.destination_connection.post(
                 f"/data/projects/{self.destination_info.id}/subjects/{subject.label}/experiments/{experiment.label}/assessors",
                 data=xml_bytes,
                 headers={"Content-Type": "text/xml"},
             )
-        self.destination_connection.projects[self.destination_info.id].subjects[subject.label].experiments[
-            experiment.label
-        ].assessors.clearcache()
+        else:
+            msg = f"Skipping creation of assessor {assessor.label} as already exists on destination."
+            LOGGER.info(msg)
+
+        destination_experiment.assessors.clearcache()
+
         try:
+            destination_assessor_id = existing_by_label.get(assessor.label)
+            if destination_assessor_id is None:
+                destination_assessor_id = destination_experiment.assessors[assessor.label].id
+
             self.mapper.update_id_map(
                 source=assessor.id,
-                destination=self.destination_connection.projects[self.destination_info.id]
-                .subjects[subject.label]
-                .experiments[experiment.label]
-                .assessors[assessor.label]
-                .id,
+                destination=destination_assessor_id,
                 map_type=XnatType.assessor,
             )
         except (KeyError, AttributeError):
             self.assess_failed_count = self.assess_failed_count + 1
-            self.destination_connection.projects[self.destination_info.id].subjects[subject.label].experiments[
-                experiment.label
-            ].assessors.clearcache()
+            destination_experiment.assessors.clearcache()
+
+            destination_assessor_id = destination_experiment.assessors[assessor.label].id
             self.mapper.update_id_map(
                 source=assessor.id,
-                destination=self.destination_connection.projects[self.destination_info.id]
-                .subjects[subject.label]
-                .experiments[experiment.label]
-                .assessors[assessor.label]
-                .id,
+                destination=destination_assessor_id,
                 map_type=XnatType.assessor,
             )
 
@@ -1114,7 +1128,7 @@ class Migration:
                 except XNATResponseError as e:
                     LOGGER.warning("Failed to share subject %s with project %s: %s", label, project_id, e)
 
-                # Share experiments
+        # Share experiments
         for label, sharing_info in self.experiment_sharing.items():
             if not sharing_info["projects"]:
                 continue
@@ -1156,6 +1170,13 @@ class Migration:
 
             for project_id in sharing_info["projects"]:
                 try:
+                    LOGGER.info(
+                        "Sharing experiment owner=%s id=%s label=%s into project=%s",
+                        owner,
+                        destination_experiment_id,
+                        label,
+                        project_id,
+                    )
                     # Use experiment ID in the URL and add label parameter
                     self.destination_connection.put(
                         f"/data/projects/{owner}/experiments/{destination_experiment_id}/projects/{project_id}?label={label}",

--- a/src/xmigrate/migration.py
+++ b/src/xmigrate/migration.py
@@ -1106,22 +1106,41 @@ class Migration:
                 except XNATResponseError as e:
                     LOGGER.warning("Failed to share subject %s with project %s: %s", label, project_id, e)
 
-        # Share experiments
+                # Share experiments
         for label, sharing_info in self.experiment_sharing.items():
             if not sharing_info["projects"]:
                 continue
 
             # Get the correct mapper based on the owner of the experiment
             owner = sharing_info["owner"]
-            for mapper in self.mappers:
-                if mapper.destination.id == owner:
+            mapper = None
+            for candidate in self.mappers:
+                if candidate.destination.id == owner:
+                    mapper = candidate
                     break
-            else:
-                msg = f"Could not find mapper for owner {owner} of experiment {label}"
-                LOGGER.warning(msg)
-                continue
 
-            destination_experiment_id = mapper.get_destination_id(sharing_info["source_id"], XnatType.experiment)
+            if mapper is not None:
+                destination_experiment_id = mapper.get_destination_id(
+                    sharing_info["source_id"],
+                    XnatType.experiment,
+                )
+            else:
+                # The owner project may have been migrated in a previous run.
+                # In that case, there is no mapper for it in this run, so look up
+                # the existing destination experiment directly by label.
+                destination_experiment_id = None
+
+                if owner not in self.destination_connection.projects:
+                    msg = f"Could not find owner project {owner} for experiment {label}"
+                    LOGGER.warning(msg)
+                    continue
+
+                owner_project = self.destination_connection.projects[owner]
+                for subject in owner_project.subjects:
+                    if label in subject.experiments:
+                        destination_experiment_id = subject.experiments[label].id
+                        break
+
             if destination_experiment_id is None:
                 msg = f"Could not find destination ID for experiment {label}"
                 LOGGER.warning(msg)
@@ -1146,15 +1165,37 @@ class Migration:
 
             # Get the correct mapper based on the owner of the assessor
             owner = sharing_info["owner"]
-            for mapper in self.mappers:
-                if mapper.destination.id == owner:
+            mapper = None
+            for candidate in self.mappers:
+                if candidate.destination.id == owner:
+                    mapper = candidate
                     break
-            else:
-                msg = f"Could not find mapper for owner {owner} of assessor {label}"
-                LOGGER.warning(msg)
-                continue
 
-            destination_assessor_id = mapper.get_destination_id(sharing_info["source_id"], XnatType.assessor)
+            if mapper is not None:
+                destination_assessor_id = mapper.get_destination_id(
+                    sharing_info["source_id"],
+                    XnatType.assessor,
+                )
+            else:
+                # The owner project may have been migrated in a previous run.
+                # In that case, there is no mapper for it in this run, so look up
+                # the existing destination assessor directly by label.
+                destination_assessor_id = None
+
+                if owner not in self.destination_connection.projects:
+                    msg = f"Could not find owner project {owner} for assessor {label}"
+                    LOGGER.warning(msg)
+                    continue
+
+                owner_project = self.destination_connection.projects[owner]
+                for subject in owner_project.subjects:
+                    for experiment in subject.experiments:
+                        if label in experiment.assessors:
+                            destination_assessor_id = experiment.assessors[label].id
+                            break
+                    if destination_assessor_id is not None:
+                        break
+
             if destination_assessor_id is None:
                 msg = f"Could not find destination ID for assessor {label}"
                 LOGGER.warning(msg)

--- a/src/xmigrate/migration.py
+++ b/src/xmigrate/migration.py
@@ -504,8 +504,7 @@ class Migration:
 
             owner_exists_on_destination = (
                 owner_project in self.destination_connection.projects
-                and subject.label
-                in self.destination_connection.projects[owner_project].subjects
+                and subject.label in self.destination_connection.projects[owner_project].subjects
             )
 
             if not owner_in_current_run and not owner_exists_on_destination:
@@ -821,7 +820,9 @@ class Migration:
             query={"format": "json"},
         ).json()["ResultSet"]["Result"]
 
-        existing_by_label = {existing_assessor["label"]: existing_assessor["ID"] for existing_assessor in existing_assessors}
+        existing_by_label = {
+            existing_assessor["label"]: existing_assessor["ID"] for existing_assessor in existing_assessors
+        }
 
         if assessor.label not in existing_by_label:
             self.destination_connection.post(

--- a/src/xmigrate/migration.py
+++ b/src/xmigrate/migration.py
@@ -1043,7 +1043,7 @@ class Migration:
                     self._refresh_catalogue(resource_path)
 
                     # Assessors are experiments in the XNAT DB, so refresh at the experiment level too
-                    resource_path = f"/archive/experiments/{assessor.id}/"
+                    resource_path = f"/archive/experiments/{assessor.id}"
                     self._refresh_catalogue(resource_path)
 
                     if assessor.label in self._roi_collections_to_populate:

--- a/src/xmigrate/migration.py
+++ b/src/xmigrate/migration.py
@@ -968,10 +968,10 @@ class Migration:
         """
         self.destination_connection.services.refresh_catalog(
             resource_path,
-            checksum=True,
-            delete=True,
+            checksum=False,
+            delete=False,
             append=True,
-            populate_stats=True,
+            populate_stats=False,
         )
 
     def _populate_roi_collection(

--- a/src/xmigrate/migration.py
+++ b/src/xmigrate/migration.py
@@ -501,21 +501,22 @@ class Migration:
             requested_projects = {info.id for info in self.all_source_info}
 
             owner_in_current_run = owner_project in requested_projects
+
             owner_exists_on_destination = (
                 owner_project in self.destination_connection.projects
-                and subject.label in self.destination_connection.projects[owner_project].subjects
+                and subject.label
+                in self.destination_connection.projects[owner_project].subjects
             )
 
             if not owner_in_current_run and not owner_exists_on_destination:
                 msg = (
                     f"Cannot migrate subject {subject.label!r} in project {self.source_info.id!r}: "
-                    f"it is owned by project {owner_project!r}, which is not included in this migration. "
+                    f"it is owned by project {owner_project!r}, which is not included in this migration "
                     f"and does not already exist on the destination. "
-                    f"Migrate {owner_project!r} first, include it in the same migration run, or rerun with the owner project included."
+                    f"Migrate {owner_project!r} first, or include it in the same migration run."
                 )
                 raise RuntimeError(msg)
 
-            # this project is not the owner of the resource, no need to create it on the destination
             sharing_info["projects"].append(self.destination_info.id)
             sharing_info["source_id"] = subject.id  # Store the source ID
             sharing_info["owner"] = owner_project

--- a/src/xmigrate/migration.py
+++ b/src/xmigrate/migration.py
@@ -1022,6 +1022,14 @@ class Migration:
         """Refresh all catalogues for the destination XNAT project."""
         for subject in self.destination_connection.projects[self.destination_info.id].subjects:
             for experiment in subject.experiments:
+                if experiment.project != self.destination_info.id:
+                    LOGGER.info(
+                        "Skipping catalogue refresh for shared experiment %s in project %s; owner is %s",
+                        experiment.label,
+                        self.destination_info.id,
+                        experiment.project,
+                    )
+                    continue
                 for scan in experiment.scans:
                     resource_path = (
                         f"/archive/projects/{self.destination_info.id}/subjects/{subject.label}/"

--- a/src/xmigrate/migration.py
+++ b/src/xmigrate/migration.py
@@ -1074,32 +1074,37 @@ class Migration:
             if not sharing_info["projects"]:
                 continue
 
-            # Get the correct mapper based on the owner of the subject
             owner = sharing_info["owner"]
-            for mapper in self.mappers:
-                if mapper.destination.id == owner:
-                    break
-            else:
-                msg = f"Could not find mapper for owner {owner} of subject {label}"
-                LOGGER.warning(msg)
-                continue
 
-            destination_subject_id = mapper.get_destination_id(sharing_info["source_id"], XnatType.subject)
-            if destination_subject_id is None:
-                msg = f"Could not find destination ID for subject {label}"
-                LOGGER.warning(msg)
-                continue
+            mapper = None
+            for candidate in self.mappers:
+                if candidate.destination.id == owner:
+                    mapper = candidate
+                    break
+
+            if mapper is not None:
+                destination_subject_id = mapper.get_destination_id(
+                    sharing_info["source_id"],
+                    XnatType.subject,
+                )
+            else:
+                if (
+                    owner not in self.destination_connection.projects
+                    or label not in self.destination_connection.projects[owner].subjects
+                ):
+                    LOGGER.warning("Could not find destination subject %s in owner project %s", label, owner)
+                    continue
+
+                destination_subject_id = self.destination_connection.projects[owner].subjects[label].id
 
             for project_id in sharing_info["projects"]:
                 try:
                     self.destination_connection.put(
                         f"/data/projects/{owner}/subjects/{destination_subject_id}/projects/{project_id}?label={label}",
                     )
-                    msg = f"Shared subject {label} with project {project_id}"
-                    LOGGER.info(msg)
+                    LOGGER.info("Shared subject %s with project %s", label, project_id)
                 except XNATResponseError as e:
-                    msg = f"Failed to share subject {label} with project {project_id}: {e}"
-                    LOGGER.warning(msg)
+                    LOGGER.warning("Failed to share subject %s with project %s: %s", label, project_id, e)
 
         # Share experiments
         for label, sharing_info in self.experiment_sharing.items():

--- a/src/xmigrate/rsync.py
+++ b/src/xmigrate/rsync.py
@@ -42,13 +42,10 @@ def run_rsync(
     pathlib.Path(rsync_destination).mkdir(parents=True, exist_ok=True)
 
     cmd = [
-        "rsync",
-        "-azP",
-        "--ignore-existing",
-        "--exclude=*.log",
-        "--exclude=.*",
-        "--stats",
-        "--checksum",
+        "fpsync",
+        "-n", "8",
+        "-v",
+        "-o", "--checksum --ignore-existing --exclude=*.log --exclude=.*",
         rsync_source + "/",
         rsync_destination,
     ]

--- a/src/xmigrate/rsync.py
+++ b/src/xmigrate/rsync.py
@@ -35,8 +35,10 @@ def run_rsync(
             If there was an error executing the rsync command.
 
     """
+    destination_rsync_path = destination_rsync_path.rstrip("/")
     rsync_destination = f"{destination_rsync_path}/{destination_project}"
-    rsync_source = f"{source_rsync_path}/{source_project}/"
+    source_rsync_path = source_rsync_path.rstrip("/")
+    rsync_source = f"{source_rsync_path}/{source_project}"
     pathlib.Path(rsync_destination).mkdir(parents=True, exist_ok=True)
 
     cmd = [
@@ -47,7 +49,7 @@ def run_rsync(
         "--exclude=.*",
         "--stats",
         "--checksum",
-        rsync_source,
+        rsync_source + "/",
         rsync_destination,
     ]
     LOGGER.info("rsync command to be run: %s", shlex.join(cmd))

--- a/src/xmigrate/rsync.py
+++ b/src/xmigrate/rsync.py
@@ -43,9 +43,11 @@ def run_rsync(
 
     cmd = [
         "fpsync",
-        "-n", "8",
+        "-n",
+        "8",
         "-v",
-        "-o", "--checksum --ignore-existing --exclude=*.log --exclude=.*",
+        "-o",
+        "--checksum --ignore-existing --exclude=*.log --exclude=.*",
         rsync_source + "/",
         rsync_destination,
     ]


### PR DESCRIPTION
Merge after #202, #203 and #204 merged to check differences

This PR:

- `migration.py` if the migration run fails then the `xmigrate.duckdb` file is moved into the `logs/` and is renamed with the datetime of failure so that when re-running the same migration to complete the migration there are not conflicts with the existing file as this `violates foreign key constraint` (For testing re-running a successful migration will result in this error which will then move the duckdb file and the migration can be run again. In reality not important for the real migration README updated to reflect this?????)