### PR TITLE
Add parallel rsync sessions with fpsync

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,12 @@ jobs:
       - name: Install only dev dependencies
         run: uv sync --only-dev
 
+      - name: Install fpsync
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y fpart
+          which fpsync
+
       - name: Test with nox
         run: uv run nox -s tests_integration
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y fpart
-          which fpsync
 
       - name: Test with nox
         run: uv run nox -s tests_integration

--- a/docker-src/Dockerfile
+++ b/docker-src/Dockerfile
@@ -49,14 +49,14 @@ RUN mkdir -p \
 ## XNAT and plugins
 WORKDIR /tmp
 RUN curl -fSL -o xnat.war \
-        "https://api.bitbucket.org/2.0/repositories/xnatdev/xnat-web/downloads/xnat-web-${XNAT_VERSION}.war" \
+        "https://github.com/NrgXnat/xnat-web/releases/download/${XNAT_VERSION}/xnat-web-${XNAT_VERSION}.war" \
     && unzip -o xnat.war -d "${TOMCAT_XNAT_FOLDER_PATH}" \
     && curl -fSL -o "${XNAT_HOME}/plugins/container-service.jar" \
-        "https://api.bitbucket.org/2.0/repositories/xnatdev/container-service/downloads/container-service-${XNAT_CS_PLUGIN_VERSION}-fat.jar" \
+        "https://github.com/NrgXnat/container-service/releases/download/${XNAT_CS_PLUGIN_VERSION}/container-service-${XNAT_CS_PLUGIN_VERSION}-fat.jar" \
     && curl -fSL -o "${XNAT_HOME}/plugins/batch-launch.jar" \
-        "https://api.bitbucket.org/2.0/repositories/xnatx/xnatx-batch-launch-plugin/downloads/batch-launch-${XNAT_BATCH_LAUNCH_PLUGIN_VERSION}-xpl.jar" \
+        "https://github.com/NrgXnat/batch-launch-plugin/releases/download/${XNAT_BATCH_LAUNCH_PLUGIN_VERSION}/batch-launch-${XNAT_BATCH_LAUNCH_PLUGIN_VERSION}-xpl.jar" \
     && curl -fSL -o "${XNAT_HOME}/plugins/ohif-viewer.jar" \
-        "https://www.xnat.org/files/ohif-viewer-xnat-plugin/ohif-viewer-${XNAT_OHIF_VIEWER_VERSION}.jar" \
+        "https://github.com/xnatworks/ohif-viewer-xnat-plugin/releases/download/${XNAT_OHIF_VIEWER_VERSION}/ohif-viewer-${XNAT_OHIF_VIEWER_VERSION}.jar" \
     && rm -rf /tmp/*
 
 ## Database initialisation

--- a/docker-src/Dockerfile
+++ b/docker-src/Dockerfile
@@ -49,14 +49,14 @@ RUN mkdir -p \
 ## XNAT and plugins
 WORKDIR /tmp
 RUN curl -fSL -o xnat.war \
-        "https://github.com/NrgXnat/xnat-web/releases/download/${XNAT_VERSION}/xnat-web-${XNAT_VERSION}.war" \
+        "https://api.bitbucket.org/2.0/repositories/xnatdev/xnat-web/downloads/xnat-web-${XNAT_VERSION}.war" \
     && unzip -o xnat.war -d "${TOMCAT_XNAT_FOLDER_PATH}" \
     && curl -fSL -o "${XNAT_HOME}/plugins/container-service.jar" \
-        "https://github.com/NrgXnat/container-service/releases/download/${XNAT_CS_PLUGIN_VERSION}/container-service-${XNAT_CS_PLUGIN_VERSION}-fat.jar" \
+        "https://api.bitbucket.org/2.0/repositories/xnatdev/container-service/downloads/container-service-${XNAT_CS_PLUGIN_VERSION}-fat.jar" \
     && curl -fSL -o "${XNAT_HOME}/plugins/batch-launch.jar" \
-        "https://github.com/NrgXnat/batch-launch-plugin/releases/download/${XNAT_BATCH_LAUNCH_PLUGIN_VERSION}/batch-launch-${XNAT_BATCH_LAUNCH_PLUGIN_VERSION}-xpl.jar" \
+        "https://api.bitbucket.org/2.0/repositories/xnatx/xnatx-batch-launch-plugin/downloads/batch-launch-${XNAT_BATCH_LAUNCH_PLUGIN_VERSION}-xpl.jar" \
     && curl -fSL -o "${XNAT_HOME}/plugins/ohif-viewer.jar" \
-        "https://github.com/xnatworks/ohif-viewer-xnat-plugin/releases/download/${XNAT_OHIF_VIEWER_VERSION}/ohif-viewer-${XNAT_OHIF_VIEWER_VERSION}.jar" \
+        "https://www.xnat.org/files/ohif-viewer-xnat-plugin/ohif-viewer-${XNAT_OHIF_VIEWER_VERSION}.jar" \
     && rm -rf /tmp/*
 
 ## Database initialisation

--- a/src/xmigrate/cli.py
+++ b/src/xmigrate/cli.py
@@ -56,6 +56,7 @@ def migrate(  # noqa: PLR0913
     source_projects: list[str] | None = None,
     *,
     include_rsync: bool = True,
+    parallel_jobs: int | None = None,
 ) -> None:
     """
     Migrate a project or projects from source to destination XNAT instance.
@@ -85,6 +86,13 @@ def migrate(  # noqa: PLR0913
     """
     logging_file_path = log_dir / "migrate.log"
     configure_logging(logging_file_path)
+    
+    if parallel_jobs is None:
+        parallel_jobs = min(8, os.cpu_count() or 1)
+
+    if parallel_jobs < 1:
+        msg = f"parallel_jobs: {parallel_jobs} value too small. Must be at least 1"
+        raise ValueError(msg)
 
     if source_projects is not None and not source_projects:
         msg = "source_projects cannot be an empty list. Use None to migrate all projects."
@@ -117,6 +125,7 @@ def migrate(  # noqa: PLR0913
                     destination_proj,
                     source_rsync,
                     source_proj,
+                    parallel_jobs
                 )
 
         try:

--- a/src/xmigrate/cli.py
+++ b/src/xmigrate/cli.py
@@ -86,7 +86,7 @@ def migrate(  # noqa: PLR0913
     """
     logging_file_path = log_dir / "migrate.log"
     configure_logging(logging_file_path)
-    
+
     if parallel_jobs is None:
         parallel_jobs = min(8, os.cpu_count() or 1)
 
@@ -120,13 +120,7 @@ def migrate(  # noqa: PLR0913
 
         if include_rsync:
             for source_proj, destination_proj in zip(source_projects, destination_projects, strict=True):
-                run_rsync(
-                    destination_rsync,
-                    destination_proj,
-                    source_rsync,
-                    source_proj,
-                    parallel_jobs
-                )
+                run_rsync(destination_rsync, destination_proj, source_rsync, source_proj, parallel_jobs)
 
         try:
             source_archive = source_connection.get("/xapi/siteConfig/archivePath").text

--- a/src/xmigrate/cli.py
+++ b/src/xmigrate/cli.py
@@ -3,7 +3,7 @@
 import logging
 import pathlib
 from logging.handlers import RotatingFileHandler
-
+import os
 import cyclopts
 import requests
 
@@ -183,6 +183,7 @@ def rsync(
     destination_rsync: str,
     log_dir: pathlib.Path = pathlib.Path("logs"),
     source_projects: list[str] | None = None,
+    parallel_jobs: int | None = None,
 ) -> None:
     """
     Migrating data from source to destination project archive or archives using rsync.
@@ -211,6 +212,13 @@ def rsync(
     logging_file_path = log_dir / "rsync.log"
     configure_logging(logging_file_path)
 
+    if parallel_jobs < 1:
+        msg = f"parallel_jobs: {parallel_jobs} value too small. Must be at least 1"
+        raise ValueError(msg)
+
+    if parallel_jobs is None:
+          parallel_jobs = min(8, os.cpu_count() or 1)
+
     if source_projects is not None and not source_projects:
         msg = "source_projects cannot be an empty list. Use None to rsync all projects."
         raise ValueError(msg)
@@ -227,6 +235,7 @@ def rsync(
             destination_proj,
             source_rsync,
             source_proj,
+            parallel_jobs
         )
 
 

--- a/src/xmigrate/cli.py
+++ b/src/xmigrate/cli.py
@@ -1,9 +1,10 @@
 """A cyclopts cli for XNAT data migration using xmigrate."""
 
 import logging
+import os
 import pathlib
 from logging.handlers import RotatingFileHandler
-import os
+
 import cyclopts
 import requests
 
@@ -177,7 +178,7 @@ def migrate(  # noqa: PLR0913
 
 
 @app.command
-def rsync(
+def rsync(  # noqa: PLR0913
     source: str,
     source_rsync: str,
     destination_rsync: str,
@@ -212,12 +213,12 @@ def rsync(
     logging_file_path = log_dir / "rsync.log"
     configure_logging(logging_file_path)
 
+    if parallel_jobs is None:
+        parallel_jobs = min(8, os.cpu_count() or 1)
+
     if parallel_jobs < 1:
         msg = f"parallel_jobs: {parallel_jobs} value too small. Must be at least 1"
         raise ValueError(msg)
-
-    if parallel_jobs is None:
-          parallel_jobs = min(8, os.cpu_count() or 1)
 
     if source_projects is not None and not source_projects:
         msg = "source_projects cannot be an empty list. Use None to rsync all projects."
@@ -230,13 +231,7 @@ def rsync(
     destination_projects = source_projects
 
     for source_proj, destination_proj in zip(source_projects, destination_projects, strict=True):
-        run_rsync(
-            destination_rsync,
-            destination_proj,
-            source_rsync,
-            source_proj,
-            parallel_jobs
-        )
+        run_rsync(destination_rsync, destination_proj, source_rsync, source_proj, parallel_jobs)
 
 
 @app.default

--- a/src/xmigrate/rsync.py
+++ b/src/xmigrate/rsync.py
@@ -42,13 +42,10 @@ def run_rsync(
     pathlib.Path(rsync_destination).mkdir(parents=True, exist_ok=True)
 
     cmd = [
-        "rsync",
-        "-azP",
-        "--ignore-existing",
-        "--exclude=*.log",
-        "--exclude=.*",
-        "--stats",
-        "--checksum",
+        "fpsync",
+        "-n", "8",
+        "-v",
+        "-o", "--checksum --ignore-existing --exclude=*.log --exclude=.*",
         rsync_source + "/",
         rsync_destination,
     ]

--- a/src/xmigrate/rsync.py
+++ b/src/xmigrate/rsync.py
@@ -35,8 +35,10 @@ def run_rsync(
             If there was an error executing the rsync command.
 
     """
+    destination_rsync_path = destination_rsync_path.rstrip("/")
     rsync_destination = f"{destination_rsync_path}/{destination_project}"
-    rsync_source = f"{source_rsync_path}/{source_project}/"
+    source_rsync_path = source_rsync_path.rstrip("/")
+    rsync_source = f"{source_rsync_path}/{source_project}"
     pathlib.Path(rsync_destination).mkdir(parents=True, exist_ok=True)
 
     cmd = [
@@ -47,7 +49,7 @@ def run_rsync(
         "--exclude=.*",
         "--stats",
         "--checksum",
-        rsync_source,
+        rsync_source + "/",
         rsync_destination,
     ]
     LOGGER.info("rsync command to be run: %s", shlex.join(cmd))

--- a/src/xmigrate/rsync.py
+++ b/src/xmigrate/rsync.py
@@ -45,7 +45,7 @@ def run_rsync(
     cmd = [
         "fpsync",
         "-n",
-        parallel_jobs,
+        str(parallel_jobs),
         "-v",
         "-o",
         "--checksum --ignore-existing --exclude=*.log --exclude=.*",

--- a/src/xmigrate/rsync.py
+++ b/src/xmigrate/rsync.py
@@ -43,9 +43,11 @@ def run_rsync(
 
     cmd = [
         "fpsync",
-        "-n", "8",
+        "-n",
+        "8",
         "-v",
-        "-o", "--checksum --ignore-existing --exclude=*.log --exclude=.*",
+        "-o",
+        "--checksum --ignore-existing --exclude=*.log --exclude=.*",
         rsync_source + "/",
         rsync_destination,
     ]

--- a/src/xmigrate/rsync.py
+++ b/src/xmigrate/rsync.py
@@ -14,6 +14,7 @@ def run_rsync(
     destination_project: str,
     source_rsync_path: str,
     source_project: str,
+    parallel_jobs: int,
 ) -> None:
     """
     Migrating data from source to destination project archive using rsync.
@@ -44,7 +45,7 @@ def run_rsync(
     cmd = [
         "fpsync",
         "-n",
-        "8",
+        parallel_jobs,
         "-v",
         "-o",
         "--checksum --ignore-existing --exclude=*.log --exclude=.*",

--- a/tests/integration/configs/test_migrate.toml
+++ b/tests/integration/configs/test_migrate.toml
@@ -4,3 +4,4 @@ source_projects = ["dummydicomproject", "OPENNEURO_T1W"]
 destination = "http://localhost:8889"
 include_rsync = true
 log_dir = "logs"
+parallel_jobs = 1


### PR DESCRIPTION
Towards #197 

This PR:
- `rsync.py` strips the trailing `/` to handle the user specifying the rsync paths with or without a trailing `/` and then adds a trailing `/` to `rsync_source` since it is required for the rsync command
- `rsync.py` replaces simple `rsync` command with `fpsync` which runs 8 parallel `rsync` sessions